### PR TITLE
CP-8940: Handle avalanche_signMessage

### DIFF
--- a/.changeset/rude-files-protect.md
+++ b/.changeset/rude-files-protect.md
@@ -1,0 +1,5 @@
+---
+'@avalabs/avalanche-module': patch
+---
+
+handle avalanche_signMessage

--- a/packages/avalanche-module/src/handlers/avalanche-sign-message/avalanche-sign-message.test.ts
+++ b/packages/avalanche-module/src/handlers/avalanche-sign-message/avalanche-sign-message.test.ts
@@ -1,0 +1,108 @@
+import { NetworkVMType, RpcMethod } from '@avalabs/vm-module-types';
+import { rpcErrors } from '@metamask/rpc-errors';
+import { avalancheSignMessage } from './avalanche-sign-message';
+
+const message = 'message to sign';
+
+const mockRequest = {
+  method: RpcMethod.AVALANCHE_SIGN_MESSAGE,
+  params: [message],
+  dappInfo: {
+    name: 'Test DApp',
+    url: 'test-url',
+    icon: 'test-icon-uri',
+  },
+  requestId: 'requestId',
+  sessionId: 'sessionId',
+  chainId: 'eip155:1',
+};
+
+const mockNetwork = {
+  chainId: 1,
+  chainName: 'Ethereum',
+  logoUri: 'test-logo-uri',
+  rpcUrl: 'rpcUrl',
+  networkToken: {
+    name: 'ethereum',
+    symbol: 'ETH',
+    decimals: 18,
+  },
+  vmName: NetworkVMType.EVM,
+};
+
+const mockApprovalController = {
+  requestApproval: jest.fn(),
+  onTransactionConfirmed: jest.fn(),
+  onTransactionReverted: jest.fn(),
+};
+
+describe('avalanche_signMessage', () => {
+  beforeEach(() => {
+    mockApprovalController.requestApproval.mockResolvedValue({ result: '0x1234' });
+  });
+
+  it('should return error when params are invalid', async () => {
+    const result = await avalancheSignMessage({
+      request: { ...mockRequest, params: ['1', '2', '3'] },
+      network: mockNetwork,
+      approvalController: mockApprovalController,
+    });
+
+    expect(result).toEqual({
+      error: rpcErrors.invalidParams('Params are invalid'),
+    });
+  });
+
+  it('should generate signingData and displayData', async () => {
+    await avalancheSignMessage({
+      request: mockRequest,
+      network: mockNetwork,
+      approvalController: mockApprovalController,
+    });
+
+    expect(mockApprovalController.requestApproval).toHaveBeenCalledWith({
+      displayData: {
+        title: 'Sign Message',
+        messageDetails: message,
+        dAppInfo: {
+          action: 'Test DApp requests you to sign the following message',
+          logoUri: 'test-icon-uri',
+          name: 'Test DApp',
+        },
+        network: {
+          chainId: 1,
+          logoUri: 'test-logo-uri',
+          name: 'Ethereum',
+        },
+      },
+      request: mockRequest,
+      signingData: {
+        accountIndex: undefined,
+        data: Buffer.from(message, 'utf-8').toString('hex'),
+        type: RpcMethod.AVALANCHE_SIGN_MESSAGE,
+      },
+    });
+  });
+
+  it('should handle success case for approvalController.requestApproval', async () => {
+    const result = await avalancheSignMessage({
+      request: mockRequest,
+      network: mockNetwork,
+      approvalController: mockApprovalController,
+    });
+
+    expect(result).toEqual({ result: '0x1234' });
+  });
+
+  it('should handle error case for approvalController.requestApproval', async () => {
+    mockApprovalController.requestApproval.mockResolvedValueOnce({ error: 'User denied message signature' });
+
+    const result = await avalancheSignMessage({
+      request: mockRequest,
+      network: mockNetwork,
+      approvalController: mockApprovalController,
+    });
+
+    expect(result).toEqual({ error: 'User denied message signature' });
+  });
+});

--- a/packages/avalanche-module/src/handlers/avalanche-sign-message/avalanche-sign-message.ts
+++ b/packages/avalanche-module/src/handlers/avalanche-sign-message/avalanche-sign-message.ts
@@ -1,0 +1,63 @@
+import {
+  type SigningData,
+  type Network,
+  type ApprovalController,
+  type DisplayData,
+  type RpcRequest,
+  RpcMethod,
+} from '@avalabs/vm-module-types';
+import { parseRequestParams } from './schemas/parse-request-params/parse-request-params';
+import { rpcErrors } from '@metamask/rpc-errors';
+
+export const avalancheSignMessage = async ({
+  request,
+  network,
+  approvalController,
+}: {
+  request: RpcRequest;
+  network: Network;
+  approvalController: ApprovalController;
+}) => {
+  const result = parseRequestParams(request.params);
+
+  if (!result.success) {
+    console.error('invalid params', result.error);
+
+    return {
+      error: rpcErrors.invalidParams('Params are invalid'),
+    };
+  }
+  const [message, accountIndex] = result.data;
+  const msgHex = Buffer.from(message, 'utf-8').toString('hex');
+  const signingData: SigningData = {
+    type: RpcMethod.AVALANCHE_SIGN_MESSAGE,
+    data: msgHex,
+    accountIndex,
+  };
+
+  const displayData: DisplayData = {
+    title: 'Sign Message',
+    dAppInfo: {
+      name: request.dappInfo.name,
+      action: `${request.dappInfo.name} requests you to sign the following message`,
+      logoUri: request.dappInfo.icon,
+    },
+    network: {
+      chainId: network.chainId,
+      name: network.chainName,
+      logoUri: network.logoUri,
+    },
+    messageDetails: message,
+  };
+
+  // prompt user for approval
+  const response = await approvalController.requestApproval({ request, displayData, signingData });
+
+  if ('error' in response) {
+    return {
+      error: response.error,
+    };
+  }
+
+  return { result: response.result };
+};

--- a/packages/avalanche-module/src/handlers/avalanche-sign-message/schemas/parse-request-params/parse-request-params.ts
+++ b/packages/avalanche-module/src/handlers/avalanche-sign-message/schemas/parse-request-params/parse-request-params.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+const paramsSchema = z.union([
+  z.tuple([z.string()]).describe('message to sign'),
+  z.tuple([z.string().describe('message to sign'), z.number().nonnegative().describe('account index')]),
+]);
+
+export const parseRequestParams = (
+  params: unknown,
+): z.SafeParseReturnType<[string, number], [string, number] | [string]> => {
+  return paramsSchema.safeParse(params);
+};

--- a/packages/avalanche-module/src/module.ts
+++ b/packages/avalanche-module/src/module.ts
@@ -10,8 +10,9 @@ import type {
   Environment,
   GetAddressParams,
   GetAddressResponse,
+  ApprovalController,
 } from '@avalabs/vm-module-types';
-import { parseManifest } from '@avalabs/vm-module-types';
+import { parseManifest, RpcMethod } from '@avalabs/vm-module-types';
 import { rpcErrors } from '@metamask/rpc-errors';
 import ManifestJson from '../manifest.json';
 import { getNetworkFee } from './handlers/get-network-fee/get-network-fee';
@@ -22,15 +23,24 @@ import { TokenService } from '@internal/utils';
 import { getBalances } from './handlers/get-balances/get-balances';
 import { hashBlockchainId } from './utils/hash-blockchain-id';
 import { getAddress } from './handlers/get-address/get-address';
+import { avalancheSignMessage } from './handlers/avalanche-sign-message/avalanche-sign-message';
 
 export class AvalancheModule implements Module {
   #glacierService: AvalancheGlacierService;
   #proxyApiUrl: string;
+  #approvalController: ApprovalController;
 
-  constructor({ environment }: { environment: Environment }) {
+  constructor({
+    approvalController,
+    environment,
+  }: {
+    approvalController: ApprovalController;
+    environment: Environment;
+  }) {
     const { glacierApiUrl, proxyApiUrl } = getEnv(environment);
     this.#glacierService = new AvalancheGlacierService({ glacierApiUrl });
     this.#proxyApiUrl = proxyApiUrl;
+    this.#approvalController = approvalController;
   }
 
   getAddress({ accountIndex, xpubXP, isTestnet, walletType }: GetAddressParams): Promise<GetAddressResponse> {
@@ -59,8 +69,10 @@ export class AvalancheModule implements Module {
     return Promise.resolve([]);
   }
 
-  async onRpcRequest(request: RpcRequest, _network: Network) {
+  async onRpcRequest(request: RpcRequest, network: Network) {
     switch (request.method) {
+      case RpcMethod.AVALANCHE_SIGN_MESSAGE:
+        return avalancheSignMessage({ request, network, approvalController: this.#approvalController });
       default:
         return { error: rpcErrors.methodNotSupported(`Method ${request.method} not supported`) };
     }

--- a/packages/evm-module/src/handlers/eth-send-transaction/eth-send-transaction.test.ts
+++ b/packages/evm-module/src/handlers/eth-send-transaction/eth-send-transaction.test.ts
@@ -114,7 +114,6 @@ const displayData = {
 const signingData = {
   type: 'eth_sendTransaction',
   account: '0xfrom',
-  chainId: 1,
   data: {
     type: 2,
     nonce: 12,

--- a/packages/evm-module/src/handlers/eth-send-transaction/eth-send-transaction.ts
+++ b/packages/evm-module/src/handlers/eth-send-transaction/eth-send-transaction.ts
@@ -131,7 +131,6 @@ export const ethSendTransaction = async ({
   const signingData: SigningData = {
     type: RpcMethod.ETH_SEND_TRANSACTION,
     account: transaction.from,
-    chainId: network.chainId,
     data: {
       type: 2, // hardcoding to 2 for now as we only support EIP-1559
       nonce: Number(transaction.nonce),

--- a/packages/evm-module/src/handlers/eth-sign/eth-sign.test.ts
+++ b/packages/evm-module/src/handlers/eth-sign/eth-sign.test.ts
@@ -204,7 +204,6 @@ describe('ethSign', () => {
         request: { ...mockRequest, method },
         signingData: {
           account: '0xabc',
-          chainId: 1,
           data: inputData,
           type: method,
         },

--- a/packages/evm-module/src/handlers/eth-sign/eth-sign.ts
+++ b/packages/evm-module/src/handlers/eth-sign/eth-sign.ts
@@ -67,7 +67,6 @@ export const ethSign = async ({
     signingData = {
       type: method,
       account: address,
-      chainId: network.chainId,
       data: data,
     };
 
@@ -79,7 +78,6 @@ export const ethSign = async ({
     signingData = {
       type: method,
       account: address,
-      chainId: network.chainId,
       data: data,
     };
 
@@ -88,7 +86,6 @@ export const ethSign = async ({
     signingData = {
       type: method,
       account: address,
-      chainId: network.chainId,
       data: data,
     };
 
@@ -97,7 +94,6 @@ export const ethSign = async ({
     signingData = {
       type: method,
       account: address,
-      chainId: network.chainId,
       data: data,
     };
 
@@ -112,11 +108,7 @@ export const ethSign = async ({
     };
   }
 
-  const {
-    alert: prioritizedAlert,
-    balanceChange,
-    tokenApprovals,
-  } = await processJsonRpcSimulation({
+  const simulationResult = await processJsonRpcSimulation({
     request,
     proxyApiUrl,
     accountAddress: address,
@@ -140,9 +132,9 @@ export const ethSign = async ({
     account: address,
     messageDetails,
     disclaimer,
-    alert: prioritizedAlert ?? alert,
-    balanceChange,
-    tokenApprovals,
+    alert: simulationResult?.alert ?? alert,
+    balanceChange: simulationResult?.balanceChange,
+    tokenApprovals: simulationResult?.tokenApprovals,
   };
 
   // prompt user for approval

--- a/packages/types/src/rpc.ts
+++ b/packages/types/src/rpc.ts
@@ -12,6 +12,9 @@ export enum RpcMethod {
   SIGN_TYPED_DATA = 'eth_signTypedData',
   PERSONAL_SIGN = 'personal_sign',
   ETH_SIGN = 'eth_sign',
+
+  /* AVALANCHE */
+  AVALANCHE_SIGN_MESSAGE = 'avalanche_signMessage',
 }
 
 export type DappInfo = {
@@ -114,26 +117,27 @@ export type SigningData =
   | {
       type: RpcMethod.ETH_SEND_TRANSACTION;
       account: string;
-      chainId: number;
       data: TransactionRequest;
     }
   | {
       type: RpcMethod.ETH_SIGN | RpcMethod.PERSONAL_SIGN;
       account: string;
-      chainId: number;
       data: string;
     }
   | {
       type: RpcMethod.SIGN_TYPED_DATA | RpcMethod.SIGN_TYPED_DATA_V1;
       account: string;
-      chainId: number;
       data: TypedData<MessageTypes> | TypedDataV1;
     }
   | {
       type: RpcMethod.SIGN_TYPED_DATA_V3 | RpcMethod.SIGN_TYPED_DATA_V4;
       account: string;
-      chainId: number;
       data: TypedData<MessageTypes>;
+    }
+  | {
+      type: RpcMethod.AVALANCHE_SIGN_MESSAGE;
+      data: string;
+      accountIndex?: number;
     };
 
 export type ApprovalParams = {


### PR DESCRIPTION
## Video
https://github.com/user-attachments/assets/6e5ad118-27b3-4358-8036-2500c6cbca5b

## Notes
It only works with the `UniversalProvider` in WalletConnect. you can try it in the playground with [this changes](https://github.com/ava-labs/extension-avalanche-playground/pull/35). 

## SigningData ##
```
{
    type: RpcMethod.AVALANCHE_SIGN_MESSAGE;
    message: string;
    accountIndex?: number;
}
```

## Figma Documentation ##
[link](https://www.figma.com/design/OvzdvcDTZdj6waAM75Y1LL/Mobile-and-Extension-Approval-Popups?node-id=0-1&t=RS28sDONLiSnt3mP-0
)