### PR TITLE
fix: versions in release pr

### DIFF
--- a/.changeset/serious-pumpkins-thank.md
+++ b/.changeset/serious-pumpkins-thank.md
@@ -1,8 +1,8 @@
 ---
-'@avalabs/avalanche-module': major
-'@avalabs/bitcoin-module': major
-'@avalabs/evm-module': major
-'@avalabs/vm-module-types': major
+'@avalabs/avalanche-module': minor
+'@avalabs/bitcoin-module': minor
+'@avalabs/evm-module': minor
+'@avalabs/vm-module-types': minor
 '@internal/utils': patch
 '@avalabs/hvm-module': patch
 '@avalabs/svm-module': patch


### PR DESCRIPTION
So the changesets in the current release PR would create versions `2.x.x`, but I want them to be `1.x.x`.

* https://github.com/ava-labs/vm-modules/pull/219

This should help 🤞 