### PR TITLE
removed fee calculation for solana, we were using on mobile but that …

### DIFF
--- a/packages/svm-module/src/utils/explain/explain-transaction.test.ts
+++ b/packages/svm-module/src/utils/explain/explain-transaction.test.ts
@@ -255,130 +255,12 @@ describe('explainTransaction', () => {
     expect(result.alert).toEqual(transactionAlerts[AlertType.DANGER]);
   });
 
-  it('should include network fee section for native SOL transfer', async () => {
+  it('should show "Interacting with" for swap transactions', async () => {
     const mockScanResponse = {
       result: {
         simulation: {
           account_summary: {
             account_assets_diff: [
-              {
-                asset: { type: 'SOL', decimals: 9 },
-                in: null,
-                out: { raw_value: 10005000, value: 0.010005 }, // 0.01 SOL + 5000 lamports fee
-              },
-            ],
-          },
-          assets_diff: {
-            mockAccount: [
-              {
-                asset: { type: 'SOL', decimals: 9 },
-                in: null,
-                out: { raw_value: 10005000, value: 0.010005 },
-              },
-            ],
-            recipientAddress: [
-              {
-                asset: { type: 'SOL', decimals: 9 },
-                in: { raw_value: 10000000, value: 0.01 }, // 0.01 SOL received
-                out: null,
-              },
-            ],
-          },
-        },
-        validation: { result_type: 'Success' },
-      },
-    } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
-
-    jest.mocked(scanSolanaTransaction).mockResolvedValueOnce(mockScanResponse);
-
-    const result = await explainTransaction({
-      simulationParams: mockSimulationParams,
-      network: mockNetwork,
-      provider: mockProvider,
-    });
-
-    expect(result.details).toContainEqual({
-      title: 'Network Fee',
-      items: [
-        {
-          label: 'Fee Amount',
-          type: 'currency',
-          value: BigInt(5000), // 10005000 - 10000000 = 5000
-          maxDecimals: 9,
-          symbol: 'SOL',
-        },
-      ],
-    });
-  });
-
-  it('should include network fee section for SPL token transfer', async () => {
-    const mockScanResponse = {
-      result: {
-        simulation: {
-          account_summary: {
-            account_assets_diff: [
-              {
-                asset: {
-                  type: 'TOKEN',
-                  name: 'Orca',
-                  symbol: 'ORCA',
-                  address: 'orcaEKTdK7LKz57vaAYr9QeNsVEPfiu6QeMU1kektZE',
-                  decimals: 6,
-                },
-                in: null,
-                out: { raw_value: 1000000, value: 1 }, // 1 ORCA transfer
-              },
-              {
-                asset: { type: 'SOL', decimals: 9 },
-                in: null,
-                out: { raw_value: 5000, value: 0.000005 }, // 5000 lamports fee
-              },
-            ],
-          },
-        },
-        validation: { result_type: 'Success' },
-      },
-    } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
-
-    jest.mocked(scanSolanaTransaction).mockResolvedValueOnce(mockScanResponse);
-
-    const result = await explainTransaction({
-      simulationParams: mockSimulationParams,
-      network: mockNetwork,
-      provider: mockProvider,
-    });
-
-    expect(result.details).toContainEqual({
-      title: 'Network Fee',
-      items: [
-        {
-          label: 'Fee Amount',
-          type: 'currency',
-          value: BigInt(5000), // Standard fee for SPL transfers
-          maxDecimals: 9,
-          symbol: 'SOL',
-        },
-      ],
-    });
-  });
-
-  it('should NOT include network fee section for swap transactions (multiple tokens)', async () => {
-    const mockScanResponse = {
-      result: {
-        simulation: {
-          account_summary: {
-            account_assets_diff: [
-              {
-                asset: {
-                  type: 'TOKEN',
-                  name: 'Fartcoin',
-                  symbol: 'FART',
-                  address: 'fart11111111111111111111111111111111111111111',
-                  decimals: 6,
-                },
-                in: { raw_value: 1343062, value: 1.343062 }, // Swap in
-                out: null,
-              },
               {
                 asset: {
                   type: 'TOKEN',
@@ -391,67 +273,20 @@ describe('explainTransaction', () => {
                 out: { raw_value: 1000000, value: 1 }, // Swap out
               },
               {
-                asset: { type: 'SOL', decimals: 9 },
-                in: null,
-                out: { raw_value: 5000, value: 0.000005 }, // Network fee, should be hidden for swaps
+                asset: {
+                  type: 'TOKEN',
+                  name: 'SOL',
+                  symbol: 'SOL',
+                  address: 'So11111111111111111111111111111111111111112',
+                  decimals: 9,
+                },
+                in: { raw_value: 1000000000, value: 1 }, // Swap in
+                out: null,
               },
             ],
           },
-        },
-        validation: { result_type: 'Success' },
-      },
-    } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
-
-    jest.mocked(scanSolanaTransaction).mockResolvedValueOnce(mockScanResponse);
-
-    const result = await explainTransaction({
-      simulationParams: mockSimulationParams,
-      network: mockNetwork,
-      provider: mockProvider,
-    });
-
-    // Should NOT contain Network Fee section for swaps
-    const networkFeeSection = result.details.find((detail) => detail.title === 'Network Fee');
-    expect(networkFeeSection).toBeUndefined();
-  });
-
-  it('should not include network fee section when fee is zero', async () => {
-    const mockScanResponse = {
-      result: {
-        simulation: {
-          account_summary: {
-            account_assets_diff: [
-              {
-                asset: { type: 'SOL', decimals: 9 },
-                in: null,
-                out: { raw_value: 0, value: 0 }, // No fee
-              },
-            ],
-          },
-        },
-        validation: { result_type: 'Success' },
-      },
-    } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
-
-    jest.mocked(scanSolanaTransaction).mockResolvedValueOnce(mockScanResponse);
-
-    const result = await explainTransaction({
-      simulationParams: mockSimulationParams,
-      network: mockNetwork,
-      provider: mockProvider,
-    });
-
-    // Should not contain Network Fee section
-    const networkFeeSection = result.details.find((detail) => detail.title === 'Network Fee');
-    expect(networkFeeSection).toBeUndefined();
-  });
-
-  it('should not include network fee section when no SOL asset is present', async () => {
-    const mockScanResponse = {
-      result: {
-        simulation: {
-          account_summary: {
-            account_assets_diff: [
+          assets_diff: {
+            mockAccount: [
               {
                 asset: {
                   type: 'TOKEN',
@@ -461,7 +296,44 @@ describe('explainTransaction', () => {
                   decimals: 6,
                 },
                 in: null,
-                out: { raw_value: 1000000, value: 1 }, // 1 USDC transfer
+                out: { raw_value: 1000000, value: 1 },
+              },
+              {
+                asset: {
+                  type: 'TOKEN',
+                  name: 'SOL',
+                  symbol: 'SOL',
+                  address: 'So11111111111111111111111111111111111111112',
+                  decimals: 9,
+                },
+                in: { raw_value: 1000000000, value: 1 },
+                out: null,
+              },
+            ],
+            contractAddress1: [
+              {
+                asset: {
+                  type: 'TOKEN',
+                  name: 'USDC',
+                  symbol: 'USDC',
+                  address: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+                  decimals: 6,
+                },
+                in: { raw_value: 1000000, value: 1 },
+                out: null,
+              },
+            ],
+            contractAddress2: [
+              {
+                asset: {
+                  type: 'TOKEN',
+                  name: 'SOL',
+                  symbol: 'SOL',
+                  address: 'So11111111111111111111111111111111111111112',
+                  decimals: 9,
+                },
+                in: null,
+                out: { raw_value: 1000000000, value: 1 },
               },
             ],
           },
@@ -478,9 +350,74 @@ describe('explainTransaction', () => {
       provider: mockProvider,
     });
 
-    // Should not contain Network Fee section
-    const networkFeeSection = result.details.find((detail) => detail.title === 'Network Fee');
-    expect(networkFeeSection).toBeUndefined();
+    // Should show "Interacting with" for swaps
+    const transactionDetails = result.details.find((detail) => detail.title === 'Transaction Details');
+    expect(transactionDetails?.items).toContainEqual({
+      label: 'Account',
+      type: 'address',
+      value: 'mockAccount',
+    });
+    expect(transactionDetails?.items).toContainEqual({
+      label: 'Interacting with',
+      type: 'addressList',
+      value: ['contractAddress1', 'contractAddress2'],
+    });
+  });
+
+  it('should show "From/To" for transfer transactions', async () => {
+    const mockScanResponse = {
+      result: {
+        simulation: {
+          account_summary: {
+            account_assets_diff: [
+              {
+                asset: { type: 'SOL', decimals: 9 },
+                in: null,
+                out: { raw_value: 10000000, value: 0.01 }, // SOL transfer out
+              },
+            ],
+          },
+          assets_diff: {
+            mockAccount: [
+              {
+                asset: { type: 'SOL', decimals: 9 },
+                in: null,
+                out: { raw_value: 10000000, value: 0.01 },
+              },
+            ],
+            recipientAddress: [
+              {
+                asset: { type: 'SOL', decimals: 9 },
+                in: { raw_value: 10000000, value: 0.01 },
+                out: null,
+              },
+            ],
+          },
+        },
+        validation: { result_type: 'Success' },
+      },
+    } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    jest.mocked(scanSolanaTransaction).mockResolvedValueOnce(mockScanResponse);
+
+    const result = await explainTransaction({
+      simulationParams: mockSimulationParams,
+      network: mockNetwork,
+      provider: mockProvider,
+    });
+
+    // Should show "From/To" for transfers
+    const transactionDetails = result.details.find((detail) => detail.title === 'Transaction Details');
+    expect(transactionDetails?.items).toContainEqual({
+      label: 'From',
+      type: 'address',
+      value: 'mockAccount',
+    });
+    expect(transactionDetails?.items).toContainEqual({
+      label: 'To',
+      type: 'address',
+      value: 'recipientAddress',
+    });
   });
 
   it('should handle simulation with empty account_assets_diff', async () => {
@@ -503,8 +440,12 @@ describe('explainTransaction', () => {
       provider: mockProvider,
     });
 
-    // Should not contain Network Fee section
-    const networkFeeSection = result.details.find((detail) => detail.title === 'Network Fee');
-    expect(networkFeeSection).toBeUndefined();
+    // Should only show Account when no other addresses are affected
+    const transactionDetails = result.details.find((detail) => detail.title === 'Transaction Details');
+    expect(transactionDetails?.items).toContainEqual({
+      label: 'Account',
+      type: 'address',
+      value: 'mockAccount',
+    });
   });
 });

--- a/packages/svm-module/src/utils/explain/explain-transaction.ts
+++ b/packages/svm-module/src/utils/explain/explain-transaction.ts
@@ -14,7 +14,7 @@ import type { ExplainTxParams } from './types';
 import { parseTransaction } from './parse-transaction';
 import { processBalanceChange } from './blockaid/process-balance-change';
 import { scanSolanaTransaction } from './blockaid/scan-solana-transaction';
-import { addressItem, currencyItem, dataItem } from '@internal/utils';
+import { addressItem, dataItem } from '@internal/utils';
 import { addressListItem } from '@internal/utils/src/utils/detail-item';
 
 export const explainTransaction = async ({
@@ -84,91 +84,6 @@ export const explainTransaction = async ({
       genericDetails.items.push(addressItem('Account', params.account));
     }
 
-    // Calculate network fee from SOL balance changes
-    // For both native SOL and SPL token transfers, the network fee is always paid in SOL
-    const accountAssetsDiff = simulation.account_summary.account_assets_diff;
-
-    if (accountAssetsDiff && accountAssetsDiff.length > 0) {
-      // Find the SOL asset in the account summary
-      const solAsset = accountAssetsDiff.find((asset) => asset.asset.type === 'SOL');
-
-      if (solAsset) {
-        let feeAmount = 0;
-
-        // Check transaction type based on asset movements
-        const tokenAssets = accountAssetsDiff.filter((asset) => asset.asset.type === 'TOKEN');
-        const outgoingAssets = accountAssetsDiff.filter((asset) => asset.out && asset.out.raw_value > 0);
-        const incomingAssets = accountAssetsDiff.filter((asset) => asset.in && asset.in.raw_value > 0);
-
-        // SOL transfers: only SOL involved, only SOL going out
-        const isSolTransfer = tokenAssets.length === 0 && solAsset && outgoingAssets.length === 1;
-
-        // SPL transfers: 1 token going out + SOL going out (for fee), no tokens coming in
-        const isSplTransfer =
-          tokenAssets.length === 1 && solAsset && outgoingAssets.length === 2 && incomingAssets.length === 0;
-
-        // Only calculate fees for transfers (not swaps)
-        if (isSolTransfer || isSplTransfer) {
-          if (isSolTransfer) {
-            // For SOL transfers, calculate fee by looking at the difference between sent and received amounts
-            const assetsDiff = simulation.assets_diff;
-            const accountAddress = params.account;
-
-            if (assetsDiff && assetsDiff[accountAddress]) {
-              const accountChanges = assetsDiff[accountAddress];
-              const solChange = accountChanges.find((change) => change.asset.type === 'SOL');
-
-              if (solChange && solChange.out) {
-                const sentAmount = solChange.out.raw_value;
-
-                // Look for the corresponding receiver to calculate the actual transfer amount
-                const allAddresses = Object.keys(assetsDiff);
-                let receivedAmount = 0;
-
-                for (const address of allAddresses) {
-                  if (address !== accountAddress) {
-                    const otherChanges = assetsDiff[address];
-                    if (otherChanges) {
-                      const otherSolChange = otherChanges.find((change) => change.asset.type === 'SOL');
-                      if (otherSolChange && otherSolChange.in) {
-                        receivedAmount = otherSolChange.in.raw_value;
-                        break;
-                      }
-                    }
-                  }
-                }
-
-                // Calculate fee as the difference
-                if (receivedAmount > 0) {
-                  feeAmount = sentAmount - receivedAmount;
-                }
-              }
-            }
-          } else if (isSplTransfer) {
-            // For SPL transfers, use standard Solana fee (no SOL recipient)
-            feeAmount = 5000; // Standard Solana network fee
-          }
-
-          // Validate that this looks like a reasonable fee
-          if (feeAmount > 0 && feeAmount <= 10000) {
-            // 0.00001 SOL max
-            // Fee is valid, keep it
-          } else {
-            feeAmount = 0;
-          }
-        }
-
-        // Only add fee section if there's an actual fee to display
-        if (feeAmount > 0) {
-          details.push({
-            title: 'Network Fee',
-            items: [
-              currencyItem('Fee Amount', BigInt(feeAmount), network.networkToken.decimals, network.networkToken.symbol),
-            ],
-          });
-        }
-      }
-    }
     isSimulationSuccessful = true;
   } else {
     // If Blockaid simulation fails, we fall back to parsing the transaction manually.


### PR DESCRIPTION
contributes to: [CP-11595](https://ava-labs.atlassian.net/browse/CP-11595)

removes fee calculation in solana svm

I added this logic initially to display network fees via the networkFeeDisplay on mobile but after further looking into XT i see that we should just be displaying this in the balance changes to match 

<img width="849" height="913" alt="Screenshot 2025-07-22 at 8 14 16 PM" src="https://github.com/user-attachments/assets/f953d9c8-178c-4a8a-a9b5-66d36a1f1a2b" />
<img width="817" height="1062" alt="Screenshot 2025-07-22 at 8 13 51 PM" src="https://github.com/user-attachments/assets/8fab7505-4a0a-4979-b9ed-fcaa5f700944" />
<img width="816" height="909" alt="Screenshot 2025-07-22 at 8 12 42 PM" src="https://github.com/user-attachments/assets/91c49fcd-1028-48c8-a239-bc8816b72692" />
<img width="783" height="920" alt="Screenshot 2025-07-22 at 8 11 00 PM" src="https://github.com/user-attachments/assets/23364221-6e1c-427b-a22e-597baf90ba2f" />
<img width="806" height="972" alt="Screenshot 2025-07-22 at 8 10 07 PM" src="https://github.com/user-attachments/assets/0a340a30-5e3e-4bad-b785-3fe749a152f1" />
