### PR TITLE
ci: modify permissions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write # Needed for changesets/action
   id-token: write # Required for OIDC authentication when publishing to NPM
-  pull-requests: write
+  pull-requests: write # Needed for changesets/action
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
Updated permissions for GitHub Actions workflow to allow write access for contents and pull requests.