### PR TITLE
ci: add commitMode for signed commits in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,7 @@ jobs:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: pnpm release
           title: 'Changesets: Versioning & Publishing'
+          commitMode: 'github-api' # signed commits
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Allows the changesets/action to sign the commits it makes for the PR. This way we don't have to pull, co-sign and force push back up.