### PR TITLE
ci: remove commitMode for GitHub API in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,6 @@ jobs:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: pnpm release
           title: 'Changesets: Versioning & Publishing'
-          commitMode: 'github-api' # signed commits
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Removed the commitMode setting for GitHub API signed commits.