### PR TITLE
fix: identify TransactionType.APPROVE

### DIFF
--- a/packages/evm-module/src/handlers/get-transaction-history/converters/etherscan-transaction-converter/convert-transaction-normal.test.ts
+++ b/packages/evm-module/src/handlers/get-transaction-history/converters/etherscan-transaction-converter/convert-transaction-normal.test.ts
@@ -54,4 +54,87 @@ describe('convertTransactionNormal ', () => {
 
     expect(result).toEqual(expected);
   });
+
+  it('classifies ERC-20 approve transactions as APPROVE', () => {
+    const approveTx = {
+      from: '0xSenderAddress',
+      to: '0xTokenContractAddress',
+      timeStamp: '1625794800',
+      value: '0',
+      gasPrice: '20000000000',
+      gasUsed: '46000',
+      hash: '0xApproveHash',
+      input:
+        '0x095ea7b3000000000000000000000000spenderaddress0000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffffffffffff',
+    } as NormalTx;
+
+    const networkToken = { name: 'Ethereum', symbol: 'ETH', decimals: 18 };
+    const address = '0xSenderAddress';
+
+    const result = convertTransactionNormal({
+      tx: approveTx,
+      networkToken,
+      chainId: 1,
+      explorerUrl: 'https://etherscan.io',
+      address,
+    });
+
+    expect(result.txType).toBe(TransactionType.APPROVE);
+    expect(result.isContractCall).toBe(true);
+  });
+
+  it('classifies increaseAllowance transactions as APPROVE', () => {
+    const increaseAllowanceTx = {
+      from: '0xSenderAddress',
+      to: '0xTokenContractAddress',
+      timeStamp: '1625794800',
+      value: '0',
+      gasPrice: '20000000000',
+      gasUsed: '46000',
+      hash: '0xIncreaseAllowanceHash',
+      input:
+        '0x39509351000000000000000000000000spenderaddress0000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffffffffffff',
+    } as NormalTx;
+
+    const networkToken = { name: 'Ethereum', symbol: 'ETH', decimals: 18 };
+    const address = '0xSenderAddress';
+
+    const result = convertTransactionNormal({
+      tx: increaseAllowanceTx,
+      networkToken,
+      chainId: 1,
+      explorerUrl: 'https://etherscan.io',
+      address,
+    });
+
+    expect(result.txType).toBe(TransactionType.APPROVE);
+    expect(result.isContractCall).toBe(true);
+  });
+
+  it('does not classify non-approve contract calls as APPROVE', () => {
+    const transferTx = {
+      from: '0xSenderAddress',
+      to: '0xTokenContractAddress',
+      timeStamp: '1625794800',
+      value: '0',
+      gasPrice: '20000000000',
+      gasUsed: '46000',
+      hash: '0xTransferHash',
+      input:
+        '0xa9059cbb000000000000000000000000recipientaddress00000000000000000000000000000000000000000000000000000000000000000000000000000000000f4240',
+    } as NormalTx;
+
+    const networkToken = { name: 'Ethereum', symbol: 'ETH', decimals: 18 };
+    const address = '0xSenderAddress';
+
+    const result = convertTransactionNormal({
+      tx: transferTx,
+      networkToken,
+      chainId: 1,
+      explorerUrl: 'https://etherscan.io',
+      address,
+    });
+
+    expect(result.txType).toBe(TransactionType.SEND);
+  });
 });

--- a/packages/evm-module/src/handlers/get-transaction-history/converters/etherscan-transaction-converter/convert-transaction-normal.ts
+++ b/packages/evm-module/src/handlers/get-transaction-history/converters/etherscan-transaction-converter/convert-transaction-normal.ts
@@ -21,7 +21,13 @@ export const convertTransactionNormal = ({
   const decimals = networkToken.decimals;
   const amount = new TokenUnit(tx.value, networkToken.decimals, networkToken.symbol);
   const amountDisplayValue = amount.toDisplay();
-  const txType = isSender ? TransactionType.SEND : TransactionType.RECEIVE;
+
+  const txType =
+    isContractCall(tx) && isApprovalTx(tx)
+      ? TransactionType.APPROVE
+      : isSender
+      ? TransactionType.SEND
+      : TransactionType.RECEIVE;
 
   const { from, to, gasPrice, gasUsed, hash } = tx;
   const explorerLink = getExplorerAddressByNetwork(explorerUrl, hash);
@@ -54,4 +60,15 @@ export const convertTransactionNormal = ({
 
 function isContractCall(tx: NormalTx): boolean {
   return tx.input !== '0x';
+}
+
+// EVM function selectors — first 4 bytes of keccak256(functionSignature).
+// These identify which function was called in tx.input calldata.
+const APPROVE_SELECTOR = '0x095ea7b3'; // keccak256("approve(address,uint256)")
+const INCREASE_ALLOWANCE_SELECTOR = '0x39509351'; // keccak256("increaseAllowance(address,uint256)")
+
+function isApprovalTx(tx: NormalTx): boolean {
+  // tx.input starts with "0x" + 8 hex chars (4 bytes) for the function selector
+  const selector = tx.input?.slice(0, 10)?.toLowerCase();
+  return selector === APPROVE_SELECTOR || selector === INCREASE_ALLOWANCE_SELECTOR;
 }


### PR DESCRIPTION
  Summary

  ERC-20 approve() and increaseAllowance() transactions from Etherscan history were being classified as SEND, causing them to show as "0 ETH sent" in the Activity tab. This updates convertTransactionNormal to detect these calls by their function selectors in tx.input and classify them as
  TransactionType.APPROVE.


  What changed

  • `convert-transaction-normal.ts` — Before assigning SEND/RECEIVE, checks if the transaction is a contract call with an approve (0x095ea7b3) or increaseAllowance (0x39509351) function selector. If so, sets txType = TransactionType.APPROVE.
  • `convert-transaction-normal.test.ts` — Added 3 tests: approve classified as APPROVE, increaseAllowance classified as APPROVE, non-approve contract call stays SEND.



  Why

  Fusion swaps trigger a separate approve transaction before the actual swap. These normal transactions have value: 0 (no native token transfer), so they appeared as "0 ETH sent" — confusing for users. With the correct type, the UI can render them with a proper label (e.g., "Spend limit
  approved").