### PR TITLE
feat(evm): add ERC-8004 agent identity approvals

### DIFF
--- a/packages/evm-module/manifest.json
+++ b/packages/evm-module/manifest.json
@@ -34,6 +34,7 @@
       "dapps": true,
       "methods": [
         "personal_sign",
+        "avalanche_declareAgentIdentity",
         "eth_sendTransaction",
         "eth_sendTransactionBatch",
         "eth_*",

--- a/packages/evm-module/src/handlers/avalanche-declare-agent-identity/avalanche-declare-agent-identity.test.ts
+++ b/packages/evm-module/src/handlers/avalanche-declare-agent-identity/avalanche-declare-agent-identity.test.ts
@@ -1,0 +1,88 @@
+import { RpcMethod, NetworkVMType, type Network, type RpcRequest } from '@avalabs/vm-module-types';
+
+import { avalancheDeclareAgentIdentity } from './avalanche-declare-agent-identity';
+import { resolveAgentIdentity } from '../../utils/resolve-agent-identity';
+
+jest.mock('../../utils/resolve-agent-identity', () => ({
+  resolveAgentIdentity: jest.fn(),
+}));
+
+const mockResolveAgentIdentity = resolveAgentIdentity as jest.MockedFunction<typeof resolveAgentIdentity>;
+
+const request = {
+  requestId: '1',
+  sessionId: '2',
+  method: RpcMethod.AVALANCHE_DECLARE_AGENT_IDENTITY,
+  chainId: 'eip155:43114',
+  params: {
+    agentId: '1599',
+    agentRegistry: 'eip155:43114:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
+  },
+  dappInfo: {
+    name: 'Test dApp',
+    url: 'https://example.com',
+    icon: 'https://example.com/icon.png',
+  },
+} as const;
+
+const network = {
+  chainId: 43114,
+  chainName: 'Avalanche',
+  rpcUrl: 'https://api.avax.network/ext/bc/C/rpc',
+  logoUri: 'logo',
+  networkToken: { name: 'AVAX', symbol: 'AVAX', decimals: 18 },
+  vmName: NetworkVMType.EVM,
+} as const;
+
+describe('avalancheDeclareAgentIdentity', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns resolved identity', async () => {
+    mockResolveAgentIdentity.mockResolvedValue({
+      agentId: '1599',
+      agentRegistry: 'eip155:43114:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
+      owner: '0x1234567890123456789012345678901234567890',
+      reputationScore: 88,
+      metadataUri: 'ipfs://agent.json',
+      trustLevel: 'high',
+    });
+
+    const result = await avalancheDeclareAgentIdentity({
+      request: request as unknown as RpcRequest,
+      network: network as unknown as Network,
+    });
+
+    expect(mockResolveAgentIdentity).toHaveBeenCalledWith({
+      declaration: request.params,
+      rpcUrl: network.rpcUrl,
+    });
+    expect(result).toEqual({
+      result: {
+        agentId: '1599',
+        agentRegistry: 'eip155:43114:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
+        owner: '0x1234567890123456789012345678901234567890',
+        reputationScore: 88,
+        metadataUri: 'ipfs://agent.json',
+        trustLevel: 'high',
+      },
+    });
+  });
+
+  it('returns invalid params for bad payloads', async () => {
+    const result = await avalancheDeclareAgentIdentity({
+      request: { ...request, params: { agentRegistry: 'bad' } } as unknown as RpcRequest,
+      network: network as unknown as Network,
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          code: -32602,
+          message: 'Agent identity params are invalid',
+        }),
+      }),
+    );
+  });
+});

--- a/packages/evm-module/src/handlers/avalanche-declare-agent-identity/avalanche-declare-agent-identity.test.ts
+++ b/packages/evm-module/src/handlers/avalanche-declare-agent-identity/avalanche-declare-agent-identity.test.ts
@@ -39,7 +39,7 @@ describe('avalancheDeclareAgentIdentity', () => {
     jest.clearAllMocks();
   });
 
-  it('returns resolved identity', async () => {
+  it('returns resolved identity for prefetch without persisting request state', async () => {
     mockResolveAgentIdentity.mockResolvedValue({
       agentId: '1599',
       agentRegistry: 'eip155:43114:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',

--- a/packages/evm-module/src/handlers/avalanche-declare-agent-identity/avalanche-declare-agent-identity.test.ts
+++ b/packages/evm-module/src/handlers/avalanche-declare-agent-identity/avalanche-declare-agent-identity.test.ts
@@ -29,6 +29,7 @@ const network = {
   chainId: 43114,
   chainName: 'Avalanche',
   rpcUrl: 'https://api.avax.network/ext/bc/C/rpc',
+  customRpcHeaders: undefined,
   logoUri: 'logo',
   networkToken: { name: 'AVAX', symbol: 'AVAX', decimals: 18 },
   vmName: NetworkVMType.EVM,
@@ -57,6 +58,9 @@ describe('avalancheDeclareAgentIdentity', () => {
     expect(mockResolveAgentIdentity).toHaveBeenCalledWith({
       declaration: request.params,
       rpcUrl: network.rpcUrl,
+      chainId: network.chainId,
+      chainName: network.chainName,
+      customRpcHeaders: network.customRpcHeaders,
     });
     expect(result).toEqual({
       result: {

--- a/packages/evm-module/src/handlers/avalanche-declare-agent-identity/avalanche-declare-agent-identity.ts
+++ b/packages/evm-module/src/handlers/avalanche-declare-agent-identity/avalanche-declare-agent-identity.ts
@@ -1,0 +1,37 @@
+import type { Network, RpcRequest } from '@avalabs/vm-module-types';
+import { rpcErrors } from '@metamask/rpc-errors';
+import { z } from 'zod';
+
+import { resolveAgentIdentity } from '../../utils/resolve-agent-identity';
+
+const schema = z.object({
+  agentId: z.coerce.string().regex(/^\d+$/),
+  agentRegistry: z.string().min(1),
+});
+
+export const avalancheDeclareAgentIdentity = async ({
+  request,
+  network,
+}: {
+  request: RpcRequest;
+  network: Network;
+}) => {
+  const parsed = schema.safeParse(request.params);
+
+  if (!parsed.success) {
+    console.error('invalid params', parsed.error);
+    return {
+      error: rpcErrors.invalidParams({
+        message: 'Agent identity params are invalid',
+        data: { cause: parsed.error.flatten() },
+      }),
+    };
+  }
+
+  return {
+    result: await resolveAgentIdentity({
+      declaration: parsed.data,
+      rpcUrl: network.rpcUrl,
+    }),
+  };
+};

--- a/packages/evm-module/src/handlers/avalanche-declare-agent-identity/avalanche-declare-agent-identity.ts
+++ b/packages/evm-module/src/handlers/avalanche-declare-agent-identity/avalanche-declare-agent-identity.ts
@@ -37,6 +37,9 @@ export const avalancheDeclareAgentIdentity = async ({
     result: await resolveAgentIdentity({
       declaration: parsed.data,
       rpcUrl: network.rpcUrl,
+      chainId: network.chainId,
+      chainName: network.chainName,
+      customRpcHeaders: network.customRpcHeaders,
     }),
   };
 };

--- a/packages/evm-module/src/handlers/avalanche-declare-agent-identity/avalanche-declare-agent-identity.ts
+++ b/packages/evm-module/src/handlers/avalanche-declare-agent-identity/avalanche-declare-agent-identity.ts
@@ -9,6 +9,11 @@ const schema = z.object({
   agentRegistry: z.string().min(1),
 });
 
+/**
+ * Prefetch-only helper for agent identity resolution.
+ * This does not persist per-dApp state; callers must still pass context.agentIdentity
+ * on signing / transaction requests when they want identity shown in approvals.
+ */
 export const avalancheDeclareAgentIdentity = async ({
   request,
   network,

--- a/packages/evm-module/src/handlers/eth-send-transaction-batch/eth-send-transaction-batch.test.ts
+++ b/packages/evm-module/src/handlers/eth-send-transaction-batch/eth-send-transaction-batch.test.ts
@@ -18,6 +18,7 @@ import { getProvider } from '../../utils/get-provider';
 import { getTxBatchUpdater } from '../../utils/evm-tx-batch-updater';
 import type { TransactionParams } from '../../types';
 import { addressItem, linkItem, networkItem } from '@internal/utils/src/utils/detail-item';
+import { resolveAgentIdentity } from '../../utils/resolve-agent-identity';
 
 // doesn't print the ugly console errors out
 jest.spyOn(global.console, 'error').mockImplementation(() => {});
@@ -34,6 +35,9 @@ jest.mock('../../utils/evm-tx-batch-updater', () => ({
 jest.mock('../../utils/estimate-gas-limit');
 jest.mock('../../utils/get-nonce');
 jest.mock('../../utils/get-provider');
+jest.mock('../../utils/resolve-agent-identity', () => ({
+  resolveAgentIdentity: jest.fn(),
+}));
 const mockBlockaid = {
   evm: {
     transactionBulk: {
@@ -58,6 +62,7 @@ const mockApprovalController: jest.Mocked<BatchApprovalController> = {
 
 const mockParseRequestParams = parseRequestParams as jest.MockedFunction<typeof parseRequestParams>;
 const mockGetNonce = getNonce as jest.MockedFunction<typeof getNonce>;
+const mockResolveAgentIdentity = resolveAgentIdentity as jest.MockedFunction<typeof resolveAgentIdentity>;
 const mockSend = jest.fn();
 const mockGetTransactionReceipt = jest.fn();
 
@@ -118,6 +123,15 @@ const testRequestParams = () => ({
   approvalController: mockApprovalController,
   blockaid: mockBlockaid as any, // eslint-disable-line @typescript-eslint/no-explicit-any
 });
+
+const testAgentIdentity = {
+  agentId: '1599',
+  agentRegistry: 'eip155:43114:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
+  owner: '0x1234567890123456789012345678901234567890',
+  reputationScore: 88,
+  metadataUri: 'ipfs://agent.json',
+  trustLevel: 'high' as const,
+};
 
 const displayData = {
   title: 'Do you approve these transactions?',
@@ -983,3 +997,46 @@ const testWithValidationResultType = async (resultType: 'Warning' | 'Error' | 'M
     });
   }
 };
+
+describe('agent identity propagation', () => {
+  it('threads resolved agent identity into batch approval payloads', async () => {
+    mockResolveAgentIdentity.mockResolvedValue(testAgentIdentity);
+    mockApprovalController.requestBatchApproval.mockResolvedValue({
+      result: [{ signedData: '0xsignedtx1' }, { signedData: '0xsignedtx2' }],
+    });
+    await ethSendTransactionBatch({
+      ...testRequestParams(),
+      request: {
+        ...testRequestParams().request,
+        context: {
+          agentIdentity: {
+            agentId: '1599',
+            agentRegistry: 'eip155:43114:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
+          },
+        },
+      },
+    });
+
+    expect(mockResolveAgentIdentity).toHaveBeenCalledWith({
+      declaration: {
+        agentId: '1599',
+        agentRegistry: 'eip155:43114:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
+      },
+      rpcUrl: testNetwork.rpcUrl,
+    });
+    expect(mockApprovalController.requestBatchApproval).toHaveBeenCalledWith(
+      expect.objectContaining({
+        displayData: expect.objectContaining({
+          agentIdentity: testAgentIdentity,
+        }),
+        signingRequests: expect.arrayContaining([
+          expect.objectContaining({
+            displayData: expect.objectContaining({
+              agentIdentity: testAgentIdentity,
+            }),
+          }),
+        ]),
+      }),
+    );
+  });
+});

--- a/packages/evm-module/src/handlers/eth-send-transaction-batch/eth-send-transaction-batch.test.ts
+++ b/packages/evm-module/src/handlers/eth-send-transaction-batch/eth-send-transaction-batch.test.ts
@@ -1027,12 +1027,30 @@ describe('agent identity propagation', () => {
     expect(mockApprovalController.requestBatchApproval).toHaveBeenCalledWith(
       expect.objectContaining({
         displayData: expect.objectContaining({
-          agentIdentity: testAgentIdentity,
+          details: expect.arrayContaining([
+            expect.objectContaining({
+              title: 'Agent Identity',
+              items: expect.arrayContaining([
+                expect.objectContaining({ label: 'Agent ID', value: testAgentIdentity.agentId }),
+                expect.objectContaining({ label: 'Registry', value: testAgentIdentity.agentRegistry }),
+                expect.objectContaining({ label: 'Trust level', value: testAgentIdentity.trustLevel }),
+              ]),
+            }),
+          ]),
         }),
         signingRequests: expect.arrayContaining([
           expect.objectContaining({
             displayData: expect.objectContaining({
-              agentIdentity: testAgentIdentity,
+              details: expect.arrayContaining([
+                expect.objectContaining({
+                  title: 'Agent Identity',
+                  items: expect.arrayContaining([
+                    expect.objectContaining({ label: 'Agent ID', value: testAgentIdentity.agentId }),
+                    expect.objectContaining({ label: 'Registry', value: testAgentIdentity.agentRegistry }),
+                    expect.objectContaining({ label: 'Trust level', value: testAgentIdentity.trustLevel }),
+                  ]),
+                }),
+              ]),
             }),
           }),
         ]),

--- a/packages/evm-module/src/handlers/eth-send-transaction-batch/eth-send-transaction-batch.test.ts
+++ b/packages/evm-module/src/handlers/eth-send-transaction-batch/eth-send-transaction-batch.test.ts
@@ -1041,6 +1041,9 @@ describe('agent identity propagation', () => {
         agentRegistry: 'eip155:43114:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
       },
       rpcUrl: testNetwork.rpcUrl,
+      chainId: testNetwork.chainId,
+      chainName: testNetwork.chainName,
+      customRpcHeaders: testNetwork.customRpcHeaders,
     });
     expect(mockApprovalController.requestBatchApproval).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/evm-module/src/handlers/eth-send-transaction-batch/eth-send-transaction-batch.ts
+++ b/packages/evm-module/src/handlers/eth-send-transaction-batch/eth-send-transaction-batch.ts
@@ -19,6 +19,8 @@ import { simulateTransactionBatch } from './utils/process-transaction-batch-simu
 import { addressItem, linkItem, networkItem } from '@internal/utils/src/utils/detail-item';
 import { rpcErrorOpts } from '@internal/utils';
 import type Blockaid from '@blockaid/client';
+import { getAgentIdentityFromContext } from '../../utils/get-agent-identity-from-context';
+import { resolveAgentIdentity } from '../../utils/resolve-agent-identity';
 
 export const ethSendTransactionBatch = async ({
   request,
@@ -83,6 +85,9 @@ export const ethSendTransactionBatch = async ({
     };
   }
 
+  const declaration = getAgentIdentityFromContext(request);
+  const agentIdentity = declaration ? await resolveAgentIdentity({ declaration, rpcUrl: network.rpcUrl }) : undefined;
+
   const displayData: DisplayData = {
     title: 'Do you approve these transactions?',
     details: [
@@ -103,9 +108,12 @@ export const ethSendTransactionBatch = async ({
     alert,
     tokenApprovals,
     networkFeeSelector: true,
+    agentIdentity,
   };
 
-  const signingRequests = scans.map((scan) => buildTxApprovalRequest(request, network, scan.transaction, scan));
+  const signingRequests = scans.map((scan) =>
+    buildTxApprovalRequest(request, network, scan.transaction, scan, agentIdentity),
+  );
   const { cleanup, updateTx } = getTxBatchUpdater(request.requestId, signingRequests, displayData);
 
   const response = await approvalController.requestBatchApproval({ request, signingRequests, displayData, updateTx });

--- a/packages/evm-module/src/handlers/eth-send-transaction-batch/eth-send-transaction-batch.ts
+++ b/packages/evm-module/src/handlers/eth-send-transaction-batch/eth-send-transaction-batch.ts
@@ -21,6 +21,7 @@ import { rpcErrorOpts } from '@internal/utils';
 import type Blockaid from '@blockaid/client';
 import { getAgentIdentityFromContext } from '../../utils/get-agent-identity-from-context';
 import { resolveAgentIdentity } from '../../utils/resolve-agent-identity';
+import { buildAgentIdentityDetailSection } from '../../utils/build-agent-identity-detail-section';
 
 export const ethSendTransactionBatch = async ({
   request,
@@ -102,13 +103,13 @@ export const ethSendTransactionBatch = async ({
           linkItem('Website', request.dappInfo),
         ],
       },
+      ...(agentIdentity ? [buildAgentIdentityDetailSection(agentIdentity)] : []),
     ],
     isSimulationSuccessful,
     balanceChange,
     alert,
     tokenApprovals,
     networkFeeSelector: true,
-    agentIdentity,
   };
 
   const signingRequests = scans.map((scan) =>

--- a/packages/evm-module/src/handlers/eth-send-transaction-batch/eth-send-transaction-batch.ts
+++ b/packages/evm-module/src/handlers/eth-send-transaction-batch/eth-send-transaction-batch.ts
@@ -88,7 +88,15 @@ export const ethSendTransactionBatch = async ({
   }
 
   const declaration = getAgentIdentityFromContext(request);
-  const agentIdentity = declaration ? await resolveAgentIdentity({ declaration, rpcUrl: network.rpcUrl }) : undefined;
+  const agentIdentity = declaration
+    ? await resolveAgentIdentity({
+        declaration,
+        rpcUrl: network.rpcUrl,
+        chainId: network.chainId,
+        chainName: network.chainName,
+        customRpcHeaders: network.customRpcHeaders,
+      })
+    : undefined;
 
   const displayData: DisplayData = {
     title: 'Do you approve these transactions?',

--- a/packages/evm-module/src/handlers/eth-send-transaction/eth-send-transaction.test.ts
+++ b/packages/evm-module/src/handlers/eth-send-transaction/eth-send-transaction.test.ts
@@ -14,6 +14,7 @@ import {
 import { ZodError } from 'zod';
 import { getProvider } from '../../utils/get-provider';
 import { getTxUpdater } from '../../utils/evm-tx-updater';
+import { resolveAgentIdentity } from '../../utils/resolve-agent-identity';
 import waitForExpect from 'wait-for-expect';
 
 // doesn't print the ugly console errors out
@@ -31,6 +32,9 @@ jest.mock('../../utils/evm-tx-updater', () => ({
 jest.mock('../../utils/estimate-gas-limit');
 jest.mock('../../utils/get-nonce');
 jest.mock('../../utils/get-provider');
+jest.mock('../../utils/resolve-agent-identity', () => ({
+  resolveAgentIdentity: jest.fn(),
+}));
 const mockBlockaid = {
   evm: {
     transaction: {
@@ -55,6 +59,7 @@ const mockApprovalController: jest.Mocked<ApprovalController> = {
 
 const mockParseRequestParams = parseRequestParams as jest.MockedFunction<typeof parseRequestParams>;
 const mockEstimateGasLimit = estimateGasLimit as jest.MockedFunction<typeof estimateGasLimit>;
+const mockResolveAgentIdentity = resolveAgentIdentity as jest.MockedFunction<typeof resolveAgentIdentity>;
 const mockGetNonce = getNonce as jest.MockedFunction<typeof getNonce>;
 const mockSend = jest.fn();
 const mockGetTransactionReceipt = jest.fn();
@@ -167,6 +172,15 @@ const signingData = {
 const testSignedTxHash = '0xsignedtxhash';
 const testTxHash = '0xtxhash';
 
+const testAgentIdentity = {
+  agentId: '1599',
+  agentRegistry: 'eip155:43114:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
+  owner: '0x1234567890123456789012345678901234567890',
+  reputationScore: 88,
+  metadataUri: 'ipfs://agent.json',
+  trustLevel: 'high' as const,
+};
+
 describe('eth_sendTransaction handler', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -177,6 +191,7 @@ describe('eth_sendTransaction handler', () => {
     });
 
     mockApprovalController.requestApproval.mockResolvedValue({ signedData: testSignedTxHash });
+    mockResolveAgentIdentity.mockResolvedValue(testAgentIdentity);
   });
 
   it('should return error if request params are invalid', async () => {
@@ -735,3 +750,37 @@ const testWithValidationResultType = async (resultType: 'Warning' | 'Error' | 'M
     });
   }
 };
+
+describe('agent identity propagation', () => {
+  it('threads resolved agent identity into approval display data', async () => {
+    mockResolveAgentIdentity.mockResolvedValue(testAgentIdentity);
+    mockApprovalController.requestApproval.mockResolvedValue({ signedData: testSignedTxHash });
+    await ethSendTransaction({
+      ...testRequestParams(),
+      request: {
+        ...testRequestParams().request,
+        context: {
+          agentIdentity: {
+            agentId: '1599',
+            agentRegistry: 'eip155:43114:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
+          },
+        },
+      },
+    });
+
+    expect(mockResolveAgentIdentity).toHaveBeenCalledWith({
+      declaration: {
+        agentId: '1599',
+        agentRegistry: 'eip155:43114:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
+      },
+      rpcUrl: testNetwork.rpcUrl,
+    });
+    expect(mockApprovalController.requestApproval).toHaveBeenCalledWith(
+      expect.objectContaining({
+        displayData: expect.objectContaining({
+          agentIdentity: testAgentIdentity,
+        }),
+      }),
+    );
+  });
+});

--- a/packages/evm-module/src/handlers/eth-send-transaction/eth-send-transaction.test.ts
+++ b/packages/evm-module/src/handlers/eth-send-transaction/eth-send-transaction.test.ts
@@ -793,6 +793,9 @@ describe('agent identity propagation', () => {
         agentRegistry: 'eip155:43114:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
       },
       rpcUrl: testNetwork.rpcUrl,
+      chainId: testNetwork.chainId,
+      chainName: testNetwork.chainName,
+      customRpcHeaders: testNetwork.customRpcHeaders,
     });
     expect(mockApprovalController.requestApproval).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/evm-module/src/handlers/eth-send-transaction/eth-send-transaction.test.ts
+++ b/packages/evm-module/src/handlers/eth-send-transaction/eth-send-transaction.test.ts
@@ -752,6 +752,17 @@ const testWithValidationResultType = async (resultType: 'Warning' | 'Error' | 'M
 };
 
 describe('agent identity propagation', () => {
+  it('does not add an Agent Identity section when no declaration is provided', async () => {
+    mockApprovalController.requestApproval.mockResolvedValue({ signedData: testSignedTxHash });
+
+    await ethSendTransaction(testRequestParams());
+
+    const displayData = mockApprovalController.requestApproval.mock.calls.at(-1)?.[0]?.displayData;
+    expect(displayData?.details).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ title: 'Agent Identity' })]),
+    );
+  });
+
   it('threads resolved agent identity into approval display data', async () => {
     mockResolveAgentIdentity.mockResolvedValue(testAgentIdentity);
     mockApprovalController.requestApproval.mockResolvedValue({ signedData: testSignedTxHash });
@@ -778,7 +789,16 @@ describe('agent identity propagation', () => {
     expect(mockApprovalController.requestApproval).toHaveBeenCalledWith(
       expect.objectContaining({
         displayData: expect.objectContaining({
-          agentIdentity: testAgentIdentity,
+          details: expect.arrayContaining([
+            expect.objectContaining({
+              title: 'Agent Identity',
+              items: expect.arrayContaining([
+                expect.objectContaining({ label: 'Agent ID', value: testAgentIdentity.agentId }),
+                expect.objectContaining({ label: 'Registry', value: testAgentIdentity.agentRegistry }),
+                expect.objectContaining({ label: 'Trust level', value: testAgentIdentity.trustLevel }),
+              ]),
+            }),
+          ]),
         }),
       }),
     );

--- a/packages/evm-module/src/handlers/eth-send-transaction/eth-send-transaction.ts
+++ b/packages/evm-module/src/handlers/eth-send-transaction/eth-send-transaction.ts
@@ -7,6 +7,8 @@ import { getTxUpdater } from '../../utils/evm-tx-updater';
 import { estimateGasLimit } from '../../utils/estimate-gas-limit';
 import { buildTxApprovalRequest } from '../../utils/build-tx-approval-request';
 import { simulateTransaction } from '../../utils/process-transaction-simulation';
+import { getAgentIdentityFromContext } from '../../utils/get-agent-identity-from-context';
+import { resolveAgentIdentity } from '../../utils/resolve-agent-identity';
 import { rpcErrorOpts } from '@internal/utils';
 
 import { parseRequestParams } from './schema';
@@ -84,6 +86,9 @@ export const ethSendTransaction = async ({
     }
   }
 
+  const declaration = getAgentIdentityFromContext(request);
+  const agentIdentity = declaration ? await resolveAgentIdentity({ declaration, rpcUrl: network.rpcUrl }) : undefined;
+
   const scan = await simulateTransaction({
     rpcMethod: request.method,
     chainId: network.chainId,
@@ -93,7 +98,7 @@ export const ethSendTransaction = async ({
     blockaid,
   });
 
-  const { displayData, signingData } = buildTxApprovalRequest(request, network, transaction, scan);
+  const { displayData, signingData } = buildTxApprovalRequest(request, network, transaction, scan, agentIdentity);
 
   const { updateTx, cleanup } = getTxUpdater(request.requestId, signingData, displayData);
   // prompt user for approval

--- a/packages/evm-module/src/handlers/eth-send-transaction/eth-send-transaction.ts
+++ b/packages/evm-module/src/handlers/eth-send-transaction/eth-send-transaction.ts
@@ -88,7 +88,15 @@ export const ethSendTransaction = async ({
   }
 
   const declaration = getAgentIdentityFromContext(request);
-  const agentIdentity = declaration ? await resolveAgentIdentity({ declaration, rpcUrl: network.rpcUrl }) : undefined;
+  const agentIdentity = declaration
+    ? await resolveAgentIdentity({
+        declaration,
+        rpcUrl: network.rpcUrl,
+        chainId: network.chainId,
+        chainName: network.chainName,
+        customRpcHeaders: network.customRpcHeaders,
+      })
+    : undefined;
 
   const scan = await simulateTransaction({
     rpcMethod: request.method,

--- a/packages/evm-module/src/handlers/eth-sign/eth-sign.test.ts
+++ b/packages/evm-module/src/handlers/eth-sign/eth-sign.test.ts
@@ -1,6 +1,7 @@
 import { ethSign } from './eth-sign';
 import { AlertType, NetworkVMType, RpcMethod } from '@avalabs/vm-module-types';
 import { rpcErrors } from '@metamask/rpc-errors';
+import { resolveAgentIdentity } from '../../utils/resolve-agent-identity';
 
 // doesn't print the ugly console errors out
 jest.spyOn(global.console, 'error').mockImplementation(() => {});
@@ -33,6 +34,10 @@ jest.mock('./utils/beautify-message/beautify-message', () => ({
   beautifyComplexMessage: jest.fn(),
 }));
 
+jest.mock('../../utils/resolve-agent-identity', () => ({
+  resolveAgentIdentity: jest.fn(),
+}));
+
 jest.mock('./utils/typeguards', () => ({
   isTypedDataV1: jest.fn(),
   isTypedData: jest.fn(),
@@ -44,6 +49,7 @@ const mockToUtf8 = require('ethers').toUtf8String;
 const mockBeautifySimpleMessage = require('./utils/beautify-message/beautify-message').beautifySimpleMessage;
 const mockBeautifyComplexMessage = require('./utils/beautify-message/beautify-message').beautifyComplexMessage;
 const mockIsTypedDataV1 = require('./utils/typeguards').isTypedDataV1;
+const mockResolveAgentIdentity = resolveAgentIdentity as jest.MockedFunction<typeof resolveAgentIdentity>;
 
 const mockRequest = {
   method: RpcMethod.ETH_SIGN,
@@ -71,6 +77,15 @@ const mockNetwork = {
   vmName: NetworkVMType.EVM,
 };
 
+const testAgentIdentity = {
+  agentId: '1599',
+  agentRegistry: 'eip155:43114:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
+  owner: '0x1234567890123456789012345678901234567890',
+  reputationScore: 88,
+  metadataUri: 'ipfs://agent.json',
+  trustLevel: 'high' as const,
+};
+
 const mockApprovalController = {
   requestApproval: jest.fn(),
   onTransactionPending: jest.fn(),
@@ -84,6 +99,44 @@ describe('ethSign', () => {
     mockApprovalController.requestApproval.mockResolvedValue({ signedData: '0x1234' });
     mockBeautifySimpleMessage.mockReturnValue('beautified simple message');
     mockBeautifyComplexMessage.mockReturnValue('beautified complex message');
+    mockResolveAgentIdentity.mockResolvedValue(testAgentIdentity);
+  });
+
+  it('threads resolved agent identity into sign approval display data', async () => {
+    mockParseRequestParams.mockReturnValueOnce({
+      success: true,
+      data: { method: RpcMethod.ETH_SIGN, data: 'data', address: '0xabc' },
+    });
+
+    await ethSign({
+      request: {
+        ...mockRequest,
+        context: {
+          agentIdentity: {
+            agentId: '1599',
+            agentRegistry: 'eip155:43114:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
+          },
+        },
+      },
+      network: mockNetwork,
+      approvalController: mockApprovalController,
+      blockaid: mockBlockaid as never,
+    });
+
+    expect(mockResolveAgentIdentity).toHaveBeenCalledWith({
+      declaration: {
+        agentId: '1599',
+        agentRegistry: 'eip155:43114:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
+      },
+      rpcUrl: mockNetwork.rpcUrl,
+    });
+    expect(mockApprovalController.requestApproval).toHaveBeenCalledWith(
+      expect.objectContaining({
+        displayData: expect.objectContaining({
+          agentIdentity: testAgentIdentity,
+        }),
+      }),
+    );
   });
 
   it('should return error when params are invalid', async () => {

--- a/packages/evm-module/src/handlers/eth-sign/eth-sign.test.ts
+++ b/packages/evm-module/src/handlers/eth-sign/eth-sign.test.ts
@@ -69,6 +69,7 @@ const mockNetwork = {
   chainName: 'Ethereum',
   logoUri: 'test-logo-uri',
   rpcUrl: 'rpcUrl',
+  customRpcHeaders: undefined,
   networkToken: {
     name: 'ethereum',
     symbol: 'ETH',
@@ -129,6 +130,9 @@ describe('ethSign', () => {
         agentRegistry: 'eip155:43114:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
       },
       rpcUrl: mockNetwork.rpcUrl,
+      chainId: mockNetwork.chainId,
+      chainName: mockNetwork.chainName,
+      customRpcHeaders: mockNetwork.customRpcHeaders,
     });
     expect(mockApprovalController.requestApproval).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/evm-module/src/handlers/eth-sign/eth-sign.test.ts
+++ b/packages/evm-module/src/handlers/eth-sign/eth-sign.test.ts
@@ -133,7 +133,16 @@ describe('ethSign', () => {
     expect(mockApprovalController.requestApproval).toHaveBeenCalledWith(
       expect.objectContaining({
         displayData: expect.objectContaining({
-          agentIdentity: testAgentIdentity,
+          details: expect.arrayContaining([
+            expect.objectContaining({
+              title: 'Agent Identity',
+              items: expect.arrayContaining([
+                expect.objectContaining({ label: 'Agent ID', value: testAgentIdentity.agentId }),
+                expect.objectContaining({ label: 'Registry', value: testAgentIdentity.agentRegistry }),
+                expect.objectContaining({ label: 'Trust level', value: testAgentIdentity.trustLevel }),
+              ]),
+            }),
+          ]),
         }),
       }),
     );

--- a/packages/evm-module/src/handlers/eth-sign/eth-sign.ts
+++ b/packages/evm-module/src/handlers/eth-sign/eth-sign.ts
@@ -18,6 +18,8 @@ import { processJsonRpcSimulation } from '../../utils/process-transaction-simula
 import { textItem } from '@internal/utils/src/utils/detail-item';
 import { rpcErrorOpts } from '@internal/utils';
 import type Blockaid from '@blockaid/client';
+import { getAgentIdentityFromContext } from '../../utils/get-agent-identity-from-context';
+import { resolveAgentIdentity } from '../../utils/resolve-agent-identity';
 
 export const ethSign = async ({
   request,
@@ -116,6 +118,9 @@ export const ethSign = async ({
     blockaid,
   });
 
+  const declaration = getAgentIdentityFromContext(request);
+  const agentIdentity = declaration ? await resolveAgentIdentity({ declaration, rpcUrl: network.rpcUrl }) : undefined;
+
   const displayData: DisplayData = {
     title: 'Sign Message',
     dAppInfo: {
@@ -138,6 +143,7 @@ export const ethSign = async ({
     alert: simulationResult?.alert ?? alert,
     balanceChange: simulationResult?.balanceChange,
     tokenApprovals: simulationResult?.tokenApprovals,
+    agentIdentity,
   };
 
   // prompt user for approval

--- a/packages/evm-module/src/handlers/eth-sign/eth-sign.ts
+++ b/packages/evm-module/src/handlers/eth-sign/eth-sign.ts
@@ -120,7 +120,15 @@ export const ethSign = async ({
   });
 
   const declaration = getAgentIdentityFromContext(request);
-  const agentIdentity = declaration ? await resolveAgentIdentity({ declaration, rpcUrl: network.rpcUrl }) : undefined;
+  const agentIdentity = declaration
+    ? await resolveAgentIdentity({
+        declaration,
+        rpcUrl: network.rpcUrl,
+        chainId: network.chainId,
+        chainName: network.chainName,
+        customRpcHeaders: network.customRpcHeaders,
+      })
+    : undefined;
 
   const displayData: DisplayData = {
     title: 'Sign Message',

--- a/packages/evm-module/src/handlers/eth-sign/eth-sign.ts
+++ b/packages/evm-module/src/handlers/eth-sign/eth-sign.ts
@@ -20,6 +20,7 @@ import { rpcErrorOpts } from '@internal/utils';
 import type Blockaid from '@blockaid/client';
 import { getAgentIdentityFromContext } from '../../utils/get-agent-identity-from-context';
 import { resolveAgentIdentity } from '../../utils/resolve-agent-identity';
+import { buildAgentIdentityDetailSection } from '../../utils/build-agent-identity-detail-section';
 
 export const ethSign = async ({
   request,
@@ -139,11 +140,11 @@ export const ethSign = async ({
         title: 'Message',
         items: [textItem('Message', messageDetails, 'vertical')],
       },
+      ...(agentIdentity ? [buildAgentIdentityDetailSection(agentIdentity)] : []),
     ],
     alert: simulationResult?.alert ?? alert,
     balanceChange: simulationResult?.balanceChange,
     tokenApprovals: simulationResult?.tokenApprovals,
-    agentIdentity,
   };
 
   // prompt user for approval

--- a/packages/evm-module/src/module.ts
+++ b/packages/evm-module/src/module.ts
@@ -28,6 +28,7 @@ import { BLOCKAID_API_KEY } from './constants';
 import { getEnv } from './env';
 import { buildDerivationPath } from './handlers/build-derivation-path/build-derivation-path';
 import { deriveAddress } from './handlers/derive-address/derive-address';
+import { avalancheDeclareAgentIdentity } from './handlers/avalanche-declare-agent-identity/avalanche-declare-agent-identity';
 import { ethSendTransactionBatch } from './handlers/eth-send-transaction-batch/eth-send-transaction-batch';
 import { ethSendTransaction } from './handlers/eth-send-transaction/eth-send-transaction';
 import { ethSign } from './handlers/eth-sign/eth-sign';
@@ -176,6 +177,11 @@ export class EvmModule implements Module {
           blockaid: this.#blockaid,
         });
       }
+      case RpcMethod.AVALANCHE_DECLARE_AGENT_IDENTITY:
+        return avalancheDeclareAgentIdentity({
+          request,
+          network,
+        });
       case RpcMethod.PERSONAL_SIGN:
       case RpcMethod.ETH_SIGN:
       case RpcMethod.SIGN_TYPED_DATA:

--- a/packages/evm-module/src/utils/build-agent-identity-detail-section.test.ts
+++ b/packages/evm-module/src/utils/build-agent-identity-detail-section.test.ts
@@ -1,0 +1,43 @@
+import { DetailItemType } from '@avalabs/vm-module-types';
+
+import { buildAgentIdentityDetailSection } from './build-agent-identity-detail-section';
+
+describe('buildAgentIdentityDetailSection', () => {
+  const baseAgentIdentity = {
+    agentId: '1599',
+    agentRegistry: 'eip155:43114:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
+    owner: '0x1234567890123456789012345678901234567890',
+    reputationScore: 88,
+    trustLevel: 'high' as const,
+  };
+
+  it('renders navigable metadata URIs as links', () => {
+    const section = buildAgentIdentityDetailSection({
+      ...baseAgentIdentity,
+      metadataUri: 'ipfs://agent.json',
+    });
+
+    expect(section.items).toContainEqual({
+      label: 'Metadata',
+      type: DetailItemType.LINK,
+      value: {
+        name: 'ipfs://agent.json',
+        url: 'ipfs://agent.json',
+      },
+    });
+  });
+
+  it('renders data URIs as non-clickable text', () => {
+    const section = buildAgentIdentityDetailSection({
+      ...baseAgentIdentity,
+      metadataUri: 'data:application/json;base64,eyJuYW1lIjoiYWdlbnQifQ==',
+    });
+
+    expect(section.items).toContainEqual({
+      label: 'Metadata',
+      type: DetailItemType.TEXT,
+      value: 'Embedded data URI',
+      alignment: 'vertical',
+    });
+  });
+});

--- a/packages/evm-module/src/utils/build-agent-identity-detail-section.ts
+++ b/packages/evm-module/src/utils/build-agent-identity-detail-section.ts
@@ -1,0 +1,27 @@
+import type { AgentIdentity, DetailItem, DetailSection } from '@avalabs/vm-module-types';
+import { addressItem, linkItem, textItem } from '@internal/utils/src/utils/detail-item';
+
+export const buildAgentIdentityDetailSection = (agentIdentity: AgentIdentity): DetailSection => {
+  const items: DetailItem[] = [
+    textItem('Agent ID', agentIdentity.agentId),
+    textItem('Registry', agentIdentity.agentRegistry, 'vertical'),
+    textItem('Trust level', agentIdentity.trustLevel),
+  ];
+
+  if (agentIdentity.reputationScore !== null) {
+    items.push(textItem('Reputation score', String(agentIdentity.reputationScore)));
+  }
+
+  if (agentIdentity.owner) {
+    items.push(addressItem('Owner', agentIdentity.owner));
+  }
+
+  if (agentIdentity.metadataUri) {
+    items.push(linkItem('Metadata', { url: agentIdentity.metadataUri, name: agentIdentity.metadataUri }));
+  }
+
+  return {
+    title: 'Agent Identity',
+    items,
+  };
+};

--- a/packages/evm-module/src/utils/build-agent-identity-detail-section.ts
+++ b/packages/evm-module/src/utils/build-agent-identity-detail-section.ts
@@ -1,6 +1,9 @@
 import type { AgentIdentity, DetailItem, DetailSection } from '@avalabs/vm-module-types';
 import { addressItem, linkItem, textItem } from '@internal/utils/src/utils/detail-item';
 
+const isNavigableMetadataUri = (metadataUri: string) =>
+  metadataUri.startsWith('https://') || metadataUri.startsWith('http://') || metadataUri.startsWith('ipfs://');
+
 export const buildAgentIdentityDetailSection = (agentIdentity: AgentIdentity): DetailSection => {
   const items: DetailItem[] = [
     textItem('Agent ID', agentIdentity.agentId),
@@ -17,7 +20,11 @@ export const buildAgentIdentityDetailSection = (agentIdentity: AgentIdentity): D
   }
 
   if (agentIdentity.metadataUri) {
-    items.push(linkItem('Metadata', { url: agentIdentity.metadataUri, name: agentIdentity.metadataUri }));
+    items.push(
+      isNavigableMetadataUri(agentIdentity.metadataUri)
+        ? linkItem('Metadata', { url: agentIdentity.metadataUri, name: agentIdentity.metadataUri })
+        : textItem('Metadata', 'Embedded data URI', 'vertical'),
+    );
   }
 
   return {

--- a/packages/evm-module/src/utils/build-tx-approval-request.ts
+++ b/packages/evm-module/src/utils/build-tx-approval-request.ts
@@ -19,6 +19,7 @@ export const buildTxApprovalRequest = (
   network: Network,
   transaction: TransactionParams,
   { isSimulationSuccessful, balanceChange, tokenApprovals, alert }: TransactionSimulationResult,
+  agentIdentity?: DisplayData['agentIdentity'],
 ) => {
   const { dappInfo } = request;
   const transactionType = parseERC20TransactionType(transaction);
@@ -55,6 +56,7 @@ export const buildTxApprovalRequest = (
     balanceChange,
     tokenApprovals,
     isSimulationSuccessful,
+    agentIdentity,
   };
 
   const signingData: SigningData = {

--- a/packages/evm-module/src/utils/build-tx-approval-request.ts
+++ b/packages/evm-module/src/utils/build-tx-approval-request.ts
@@ -1,5 +1,6 @@
 import {
   RpcMethod,
+  type AgentIdentity,
   type DetailItem,
   type DisplayData,
   type Network,
@@ -10,6 +11,8 @@ import {
 
 import { addressItem, linkItem, networkItem } from '@internal/utils/src/utils/detail-item';
 
+import { buildAgentIdentityDetailSection } from './build-agent-identity-detail-section';
+
 import { ERC20TransactionType } from '../types';
 import type { TransactionParams } from './transaction-schema';
 import { parseERC20TransactionType } from './parse-erc20-transaction-type';
@@ -19,7 +22,7 @@ export const buildTxApprovalRequest = (
   network: Network,
   transaction: TransactionParams,
   { isSimulationSuccessful, balanceChange, tokenApprovals, alert }: TransactionSimulationResult,
-  agentIdentity?: DisplayData['agentIdentity'],
+  agentIdentity?: AgentIdentity,
 ) => {
   const { dappInfo } = request;
   const transactionType = parseERC20TransactionType(transaction);
@@ -50,13 +53,13 @@ export const buildTxApprovalRequest = (
         title: 'Transaction Details',
         items: transactionDetails,
       },
+      ...(agentIdentity ? [buildAgentIdentityDetailSection(agentIdentity)] : []),
     ],
     networkFeeSelector: true,
     alert,
     balanceChange,
     tokenApprovals,
     isSimulationSuccessful,
-    agentIdentity,
   };
 
   const signingData: SigningData = {

--- a/packages/evm-module/src/utils/get-agent-identity-from-context.ts
+++ b/packages/evm-module/src/utils/get-agent-identity-from-context.ts
@@ -1,0 +1,15 @@
+import type { AgentIdentityDeclaration, RpcRequest } from '@avalabs/vm-module-types';
+
+const isAgentIdentityDeclaration = (value: unknown): value is AgentIdentityDeclaration => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return typeof candidate.agentId === 'string' && typeof candidate.agentRegistry === 'string';
+};
+
+export const getAgentIdentityFromContext = (request: RpcRequest): AgentIdentityDeclaration | null => {
+  const candidate = request.context?.agentIdentity;
+  return isAgentIdentityDeclaration(candidate) ? candidate : null;
+};

--- a/packages/evm-module/src/utils/resolve-agent-identity.test.ts
+++ b/packages/evm-module/src/utils/resolve-agent-identity.test.ts
@@ -1,0 +1,89 @@
+import { resolveAgentIdentity } from './resolve-agent-identity';
+import { getProvider } from './get-provider';
+
+const mockProvider = { provider: 'mock' };
+const identityAddress = '0x8004A169FB4a3325136EB29fA0ceB6D2e539a432';
+const reputationAddress = '0x8004BAa17C55a88189AE136b182e5fdA19dE9b63';
+
+jest.mock('./get-provider', () => ({
+  getProvider: jest.fn(),
+}));
+
+jest.mock('ethers', () => {
+  const contractMock = jest.fn((address: string, _abi: unknown, provider: unknown) => {
+    if (address === identityAddress) {
+      return {
+        provider,
+        ownerOf: jest.fn().mockResolvedValue('0x1234567890123456789012345678901234567890'),
+        tokenURI: jest.fn().mockResolvedValue('ipfs://agent.json'),
+        agentURI: jest.fn(),
+        getMetadata: jest.fn(),
+      };
+    }
+
+    if (address === reputationAddress) {
+      return {
+        provider,
+        getScore: jest.fn().mockResolvedValue(88n),
+        getReputation: jest.fn(),
+        reputationScores: jest.fn(),
+        scores: jest.fn(),
+        reputations: jest.fn(),
+      };
+    }
+
+    throw new Error(`Unexpected contract address: ${address}`);
+  });
+
+  return {
+    Contract: contractMock,
+    getAddress: jest.fn((address: string) => address),
+    toUtf8String: jest.fn(() => 'decoded-metadata'),
+  };
+});
+
+const mockGetProvider = getProvider as jest.MockedFunction<typeof getProvider>;
+const { Contract } = jest.requireMock('ethers') as { Contract: jest.Mock };
+
+describe('resolveAgentIdentity', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetProvider.mockResolvedValue(mockProvider as never);
+  });
+
+  it('uses getProvider with customRpcHeaders so identity eth_calls inherit RPC headers', async () => {
+    const result = await resolveAgentIdentity({
+      declaration: {
+        agentId: '1599',
+        agentRegistry: `eip155:43114:${identityAddress}`,
+      },
+      rpcUrl: 'https://rpc.example/resolve-agent-identity-test',
+      chainId: 43114,
+      chainName: 'Avalanche',
+      customRpcHeaders: {
+        Authorization: 'Bearer secret',
+        'X-Trace-Id': 'trace-123',
+      },
+    });
+
+    expect(mockGetProvider).toHaveBeenCalledWith({
+      chainId: 43114,
+      chainName: 'Avalanche',
+      rpcUrl: 'https://rpc.example/resolve-agent-identity-test',
+      customRpcHeaders: {
+        Authorization: 'Bearer secret',
+        'X-Trace-Id': 'trace-123',
+      },
+    });
+    expect(Contract).toHaveBeenNthCalledWith(1, identityAddress, expect.anything(), mockProvider);
+    expect(Contract).toHaveBeenNthCalledWith(2, reputationAddress, expect.anything(), mockProvider);
+    expect(result).toEqual({
+      agentId: '1599',
+      agentRegistry: `eip155:43114:${identityAddress}`,
+      owner: '0x1234567890123456789012345678901234567890',
+      reputationScore: 88,
+      metadataUri: 'ipfs://agent.json',
+      trustLevel: 'high',
+    });
+  });
+});

--- a/packages/evm-module/src/utils/resolve-agent-identity.test.ts
+++ b/packages/evm-module/src/utils/resolve-agent-identity.test.ts
@@ -24,11 +24,17 @@ jest.mock('ethers', () => {
     if (address === reputationAddress) {
       return {
         provider,
-        getScore: jest.fn().mockResolvedValue(88n),
-        getReputation: jest.fn(),
-        reputationScores: jest.fn(),
-        scores: jest.fn(),
-        reputations: jest.fn(),
+        getIdentityRegistry: jest.fn().mockResolvedValue(identityAddress),
+        getSummary: jest.fn().mockResolvedValue([2n, 88n, 0n]),
+        readAllFeedback: jest.fn().mockResolvedValue([
+          ['0x1111111111111111111111111111111111111111', '0x2222222222222222222222222222222222222222'],
+          [1n, 2n],
+          [90n, 86n],
+          [0n, 0n],
+          ['starred', 'starred'],
+          ['', ''],
+          [false, false],
+        ]),
       };
     }
 
@@ -85,5 +91,61 @@ describe('resolveAgentIdentity', () => {
       metadataUri: 'ipfs://agent.json',
       trustLevel: 'high',
     });
+  });
+
+  it('falls back to averaging standard ERC-8004 feedback when summary cannot be queried', async () => {
+    const reputationContract = Contract.mock.results[1]?.value;
+    if (reputationContract) {
+      reputationContract.getSummary.mockRejectedValueOnce(new Error('clientAddresses required'));
+    }
+
+    const result = await resolveAgentIdentity({
+      declaration: {
+        agentId: '1599',
+        agentRegistry: `eip155:43114:${identityAddress}`,
+      },
+      rpcUrl: 'https://rpc.example/resolve-agent-identity-test',
+      chainId: 43114,
+      chainName: 'Avalanche',
+    });
+
+    expect(result.reputationScore).toBe(88);
+    expect(result.trustLevel).toBe('high');
+  });
+
+  it('ignores reputation when the reputation registry is bound to a different identity registry', async () => {
+    const customContract = jest.fn((address: string, _abi: unknown, provider: unknown) => {
+      if (address === identityAddress) {
+        return {
+          provider,
+          ownerOf: jest.fn().mockResolvedValue('0x1234567890123456789012345678901234567890'),
+          tokenURI: jest.fn().mockResolvedValue('ipfs://agent.json'),
+          agentURI: jest.fn(),
+          getMetadata: jest.fn(),
+        };
+      }
+
+      return {
+        provider,
+        getIdentityRegistry: jest.fn().mockResolvedValue('0x9999999999999999999999999999999999999999'),
+        getSummary: jest.fn(),
+        readAllFeedback: jest.fn(),
+      };
+    });
+
+    Contract.mockImplementation(customContract);
+
+    const result = await resolveAgentIdentity({
+      declaration: {
+        agentId: '1600',
+        agentRegistry: `eip155:43114:${identityAddress}`,
+      },
+      rpcUrl: 'https://rpc.example/resolve-agent-identity-test-mismatch',
+      chainId: 43114,
+      chainName: 'Avalanche',
+    });
+
+    expect(result.reputationScore).toBeNull();
+    expect(result.trustLevel).toBe('unknown');
   });
 });

--- a/packages/evm-module/src/utils/resolve-agent-identity.test.ts
+++ b/packages/evm-module/src/utils/resolve-agent-identity.test.ts
@@ -148,4 +148,42 @@ describe('resolveAgentIdentity', () => {
     expect(result.reputationScore).toBeNull();
     expect(result.trustLevel).toBe('unknown');
   });
+
+  it('falls back to unknown reputation when feedback reads fail', async () => {
+    const customContract = jest.fn((address: string, _abi: unknown, provider: unknown) => {
+      if (address === identityAddress) {
+        return {
+          provider,
+          ownerOf: jest.fn().mockResolvedValue('0x1234567890123456789012345678901234567890'),
+          tokenURI: jest.fn().mockResolvedValue('ipfs://agent.json'),
+          agentURI: jest.fn(),
+          getMetadata: jest.fn(),
+        };
+      }
+
+      return {
+        provider,
+        getIdentityRegistry: jest.fn().mockResolvedValue(identityAddress),
+        getSummary: jest.fn(),
+        readAllFeedback: jest.fn().mockRejectedValue(new Error('rpc down')),
+      };
+    });
+
+    Contract.mockImplementation(customContract);
+
+    const result = await resolveAgentIdentity({
+      declaration: {
+        agentId: '1601',
+        agentRegistry: `eip155:43114:${identityAddress}`,
+      },
+      rpcUrl: 'https://rpc.example/resolve-agent-identity-test-feedback-failure',
+      chainId: 43114,
+      chainName: 'Avalanche',
+    });
+
+    expect(result.owner).toBe('0x1234567890123456789012345678901234567890');
+    expect(result.metadataUri).toBe('ipfs://agent.json');
+    expect(result.reputationScore).toBeNull();
+    expect(result.trustLevel).toBe('unknown');
+  });
 });

--- a/packages/evm-module/src/utils/resolve-agent-identity.ts
+++ b/packages/evm-module/src/utils/resolve-agent-identity.ts
@@ -1,0 +1,156 @@
+import type { AgentIdentity, AgentIdentityDeclaration } from '@avalabs/vm-module-types';
+import { Contract, JsonRpcProvider, getAddress, toUtf8String } from 'ethers';
+
+const FIVE_MINUTES_MS = 5 * 60 * 1000;
+const DEFAULT_REPUTATION_REGISTRIES: Record<number, string> = {
+  43114: '0x8004BAa17C55a88189AE136b182e5fdA19dE9b63',
+};
+
+const IDENTITY_ABI = [
+  'function ownerOf(uint256 tokenId) view returns (address)',
+  'function tokenURI(uint256 tokenId) view returns (string)',
+  'function agentURI(uint256 agentId) view returns (string)',
+  'function getMetadata(uint256 agentId, string metadataKey) view returns (bytes)',
+] as const;
+
+const REPUTATION_ABI = [
+  'function getScore(uint256 agentId) view returns (int256)',
+  'function getReputation(uint256 agentId) view returns (int256)',
+  'function reputationScores(uint256 agentId) view returns (int256)',
+  'function scores(uint256 agentId) view returns (int256)',
+  'function reputations(uint256 agentId) view returns (int256)',
+] as const;
+
+const cache = new Map<string, { expiresAt: number; value: AgentIdentity }>();
+
+const getTrustLevel = (score: number | null): AgentIdentity['trustLevel'] => {
+  if (score === null) return 'unknown';
+  if (score >= 75) return 'high';
+  if (score >= 40) return 'medium';
+  return 'low';
+};
+
+const clampScore = (value: bigint | number | null): number | null => {
+  if (value === null) return null;
+  const score = typeof value === 'bigint' ? Number(value) : value;
+  if (!Number.isFinite(score)) return null;
+  return Math.max(0, Math.min(100, Math.trunc(score)));
+};
+
+const parseAgentRegistry = (agentRegistry: string) => {
+  const [namespace, chainId, address] = agentRegistry.split(':');
+  if (namespace !== 'eip155' || !chainId || !address) {
+    return null;
+  }
+
+  const parsedChainId = Number(chainId);
+  if (!Number.isInteger(parsedChainId)) {
+    return null;
+  }
+
+  try {
+    return { chainId: parsedChainId, address: getAddress(address) };
+  } catch {
+    return null;
+  }
+};
+
+const buildFallback = (declaration: AgentIdentityDeclaration): AgentIdentity => ({
+  agentId: declaration.agentId,
+  agentRegistry: declaration.agentRegistry,
+  owner: null,
+  reputationScore: null,
+  metadataUri: null,
+  trustLevel: 'unknown',
+});
+
+const callFirst = async <T>(calls: (() => Promise<T>)[]): Promise<T | null> => {
+  const results = await Promise.allSettled(calls.map((call) => call()));
+  for (const result of results) {
+    if (result.status === 'fulfilled' && result.value != null) {
+      return result.value;
+    }
+  }
+  return null;
+};
+
+const decodeMetadata = (value: string): string | null => {
+  if (!value || value === '0x') return null;
+  try {
+    return toUtf8String(value);
+  } catch {
+    return null;
+  }
+};
+
+export const resolveAgentIdentity = async ({
+  declaration,
+  rpcUrl,
+}: {
+  declaration: AgentIdentityDeclaration;
+  rpcUrl: string;
+}): Promise<AgentIdentity> => {
+  const cached = cache.get(`${rpcUrl}:${declaration.agentRegistry}:${declaration.agentId}`);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.value;
+  }
+
+  const parsedRegistry = parseAgentRegistry(declaration.agentRegistry);
+  if (!parsedRegistry) {
+    return buildFallback(declaration);
+  }
+
+  if (!/^\d+$/.test(declaration.agentId)) {
+    return buildFallback({
+      ...declaration,
+      agentRegistry: `eip155:${parsedRegistry.chainId}:${parsedRegistry.address}`,
+    });
+  }
+
+  const normalizedDeclaration = {
+    ...declaration,
+    agentRegistry: `eip155:${parsedRegistry.chainId}:${parsedRegistry.address}`,
+  };
+
+  const fallback = buildFallback(normalizedDeclaration);
+
+  const provider = new JsonRpcProvider(rpcUrl);
+  const identityContract = new Contract(parsedRegistry.address, IDENTITY_ABI, provider);
+
+  const reputationRegistry = DEFAULT_REPUTATION_REGISTRIES[parsedRegistry.chainId];
+  const reputationContract = reputationRegistry ? new Contract(reputationRegistry, REPUTATION_ABI, provider) : null;
+
+  const [owner, metadataUri, reputationScore] = await Promise.all([
+    callFirst<string | null>([async () => getAddress(await identityContract.ownerOf(BigInt(declaration.agentId)))]),
+    callFirst<string | null>([
+      async () => await identityContract.tokenURI(BigInt(declaration.agentId)),
+      async () => await identityContract.agentURI(BigInt(declaration.agentId)),
+      async () => decodeMetadata(await identityContract.getMetadata(BigInt(declaration.agentId), 'agentURI')),
+      async () => decodeMetadata(await identityContract.getMetadata(BigInt(declaration.agentId), 'uri')),
+    ]),
+    reputationContract
+      ? callFirst<bigint | number>([
+          async () => await reputationContract.getScore(BigInt(declaration.agentId)),
+          async () => await reputationContract.getReputation(BigInt(declaration.agentId)),
+          async () => await reputationContract.reputationScores(BigInt(declaration.agentId)),
+          async () => await reputationContract.scores(BigInt(declaration.agentId)),
+          async () => await reputationContract.reputations(BigInt(declaration.agentId)),
+        ])
+      : Promise.resolve(null),
+  ]);
+
+  const resolved: AgentIdentity = {
+    ...fallback,
+    owner: owner ?? null,
+    metadataUri: metadataUri ?? null,
+    reputationScore: clampScore(reputationScore ?? null),
+    trustLevel: getTrustLevel(clampScore(reputationScore ?? null)),
+  };
+
+  cache.set(`${rpcUrl}:${declaration.agentRegistry}:${declaration.agentId}`, {
+    expiresAt: Date.now() + FIVE_MINUTES_MS,
+    value: resolved,
+  });
+
+  return resolved;
+};

--- a/packages/evm-module/src/utils/resolve-agent-identity.ts
+++ b/packages/evm-module/src/utils/resolve-agent-identity.ts
@@ -1,5 +1,7 @@
 import type { AgentIdentity, AgentIdentityDeclaration } from '@avalabs/vm-module-types';
-import { Contract, JsonRpcProvider, getAddress, toUtf8String } from 'ethers';
+import { Contract, getAddress, toUtf8String } from 'ethers';
+
+import { getProvider } from './get-provider';
 
 const FIVE_MINUTES_MS = 5 * 60 * 1000;
 const DEFAULT_REPUTATION_REGISTRIES: Record<number, string> = {
@@ -20,6 +22,21 @@ const REPUTATION_ABI = [
   'function scores(uint256 agentId) view returns (int256)',
   'function reputations(uint256 agentId) view returns (int256)',
 ] as const;
+
+type IdentityContract = Contract & {
+  ownerOf: (tokenId: bigint) => Promise<string>;
+  tokenURI: (tokenId: bigint) => Promise<string>;
+  agentURI: (agentId: bigint) => Promise<string>;
+  getMetadata: (agentId: bigint, metadataKey: string) => Promise<string>;
+};
+
+type ReputationContract = Contract & {
+  getScore: (agentId: bigint) => Promise<bigint | number>;
+  getReputation: (agentId: bigint) => Promise<bigint | number>;
+  reputationScores: (agentId: bigint) => Promise<bigint | number>;
+  scores: (agentId: bigint) => Promise<bigint | number>;
+  reputations: (agentId: bigint) => Promise<bigint | number>;
+};
 
 const cache = new Map<string, { expiresAt: number; value: AgentIdentity }>();
 
@@ -86,9 +103,15 @@ const decodeMetadata = (value: string): string | null => {
 export const resolveAgentIdentity = async ({
   declaration,
   rpcUrl,
+  chainId,
+  chainName,
+  customRpcHeaders,
 }: {
   declaration: AgentIdentityDeclaration;
   rpcUrl: string;
+  chainId: number;
+  chainName: string;
+  customRpcHeaders?: Record<string, string>;
 }): Promise<AgentIdentity> => {
   const cached = cache.get(`${rpcUrl}:${declaration.agentRegistry}:${declaration.agentId}`);
   if (cached && cached.expiresAt > Date.now()) {
@@ -114,11 +137,18 @@ export const resolveAgentIdentity = async ({
 
   const fallback = buildFallback(normalizedDeclaration);
 
-  const provider = new JsonRpcProvider(rpcUrl);
-  const identityContract = new Contract(parsedRegistry.address, IDENTITY_ABI, provider);
+  const provider = await getProvider({
+    chainId,
+    chainName,
+    rpcUrl,
+    customRpcHeaders,
+  });
+  const identityContract = new Contract(parsedRegistry.address, IDENTITY_ABI, provider) as IdentityContract;
 
   const reputationRegistry = DEFAULT_REPUTATION_REGISTRIES[parsedRegistry.chainId];
-  const reputationContract = reputationRegistry ? new Contract(reputationRegistry, REPUTATION_ABI, provider) : null;
+  const reputationContract = reputationRegistry
+    ? (new Contract(reputationRegistry, REPUTATION_ABI, provider) as ReputationContract)
+    : null;
 
   const [owner, metadataUri, reputationScore] = await Promise.all([
     callFirst<string | null>([async () => getAddress(await identityContract.ownerOf(BigInt(declaration.agentId)))]),

--- a/packages/evm-module/src/utils/resolve-agent-identity.ts
+++ b/packages/evm-module/src/utils/resolve-agent-identity.ts
@@ -16,11 +16,9 @@ const IDENTITY_ABI = [
 ] as const;
 
 const REPUTATION_ABI = [
-  'function getScore(uint256 agentId) view returns (int256)',
-  'function getReputation(uint256 agentId) view returns (int256)',
-  'function reputationScores(uint256 agentId) view returns (int256)',
-  'function scores(uint256 agentId) view returns (int256)',
-  'function reputations(uint256 agentId) view returns (int256)',
+  'function getSummary(uint256 agentId, address[] clientAddresses, string tag1, string tag2) view returns (uint64 count, int128 summaryValue, uint8 summaryValueDecimals)',
+  'function readAllFeedback(uint256 agentId, address[] clientAddresses, string tag1, string tag2, bool includeRevoked) view returns (address[] clients, uint64[] feedbackIndexes, int128[] values, uint8[] valueDecimals, string[] tag1s, string[] tag2s, bool[] isRevoked)',
+  'function getIdentityRegistry() view returns (address)',
 ] as const;
 
 type IdentityContract = Contract & {
@@ -30,12 +28,58 @@ type IdentityContract = Contract & {
   getMetadata: (agentId: bigint, metadataKey: string) => Promise<string>;
 };
 
+type ReputationSummary = {
+  count: bigint | number;
+  summaryValue: bigint | number;
+  summaryValueDecimals: bigint | number;
+};
+
+type ReputationFeedback = {
+  value: bigint | number;
+  valueDecimals: bigint | number;
+  tag1?: string;
+  tag2?: string;
+  isRevoked?: boolean;
+};
+
+type ReputationSummaryTuple = readonly [bigint | number, bigint | number, bigint | number];
+type ReputationFeedbackTuple = readonly [
+  string[],
+  (bigint | number)[],
+  (bigint | number)[],
+  (bigint | number)[],
+  string[],
+  string[],
+  boolean[],
+];
+
+type ReputationFeedbackResult =
+  | ReputationFeedbackTuple
+  | {
+      clients: string[];
+      feedbackIndexes: (bigint | number)[];
+      values: (bigint | number)[];
+      valueDecimals: (bigint | number)[];
+      tag1s: string[];
+      tag2s: string[];
+      isRevoked: boolean[];
+    };
+
 type ReputationContract = Contract & {
-  getScore: (agentId: bigint) => Promise<bigint | number>;
-  getReputation: (agentId: bigint) => Promise<bigint | number>;
-  reputationScores: (agentId: bigint) => Promise<bigint | number>;
-  scores: (agentId: bigint) => Promise<bigint | number>;
-  reputations: (agentId: bigint) => Promise<bigint | number>;
+  getIdentityRegistry: () => Promise<string>;
+  getSummary: (
+    agentId: bigint,
+    clientAddresses: string[],
+    tag1: string,
+    tag2: string,
+  ) => Promise<ReputationSummaryTuple | ReputationSummary>;
+  readAllFeedback: (
+    agentId: bigint,
+    clientAddresses: string[],
+    tag1: string,
+    tag2: string,
+    includeRevoked: boolean,
+  ) => Promise<ReputationFeedbackResult>;
 };
 
 const cache = new Map<string, { expiresAt: number; value: AgentIdentity }>();
@@ -47,11 +91,118 @@ const getTrustLevel = (score: number | null): AgentIdentity['trustLevel'] => {
   return 'low';
 };
 
-const clampScore = (value: bigint | number | null): number | null => {
+const clampScore = (value: number | null): number | null => {
   if (value === null) return null;
-  const score = typeof value === 'bigint' ? Number(value) : value;
-  if (!Number.isFinite(score)) return null;
-  return Math.max(0, Math.min(100, Math.trunc(score)));
+  if (!Number.isFinite(value)) return null;
+  return Math.max(0, Math.min(100, Math.trunc(value)));
+};
+
+const toNumber = (value: bigint | number): number | null => {
+  const numeric = typeof value === 'bigint' ? Number(value) : value;
+  return Number.isFinite(numeric) ? numeric : null;
+};
+
+const scaleFixedPoint = (value: bigint | number, decimals: bigint | number): number | null => {
+  const numericValue = toNumber(value);
+  const numericDecimals = toNumber(decimals);
+
+  if (numericValue === null || numericDecimals === null || numericDecimals < 0) {
+    return null;
+  }
+
+  return numericValue / 10 ** numericDecimals;
+};
+
+const isReputationSummaryTuple = (
+  summary: ReputationSummaryTuple | ReputationSummary,
+): summary is ReputationSummaryTuple => Array.isArray(summary);
+
+const isReputationFeedbackTuple = (feedback: ReputationFeedbackResult): feedback is ReputationFeedbackTuple =>
+  Array.isArray(feedback);
+
+const getSummaryValue = (summary: ReputationSummaryTuple | ReputationSummary): ReputationSummary => {
+  if (isReputationSummaryTuple(summary)) {
+    return {
+      count: summary[0],
+      summaryValue: summary[1],
+      summaryValueDecimals: summary[2],
+    };
+  }
+
+  return summary;
+};
+
+const getFeedbackValues = (feedback: ReputationFeedbackResult): ReputationFeedback[] => {
+  const values = isReputationFeedbackTuple(feedback) ? feedback[2] : feedback.values;
+  const valueDecimals = isReputationFeedbackTuple(feedback) ? feedback[3] : feedback.valueDecimals;
+  const tag1s = isReputationFeedbackTuple(feedback) ? feedback[4] : feedback.tag1s;
+  const tag2s = isReputationFeedbackTuple(feedback) ? feedback[5] : feedback.tag2s;
+  const revoked = isReputationFeedbackTuple(feedback) ? feedback[6] : feedback.isRevoked;
+
+  return values.map((value: bigint | number, index: number) => ({
+    value,
+    valueDecimals: valueDecimals[index] ?? 0,
+    tag1: tag1s[index],
+    tag2: tag2s[index],
+    isRevoked: revoked[index],
+  }));
+};
+
+const averageScores = (scores: Array<number | null>): number | null => {
+  const filtered = scores.filter((score): score is number => score !== null);
+  if (!filtered.length) return null;
+  return filtered.reduce((sum, score) => sum + score, 0) / filtered.length;
+};
+
+const STARRED_TAG = 'starred';
+
+const dedupeAddresses = (addresses: string[]): string[] => {
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+
+  for (const address of addresses) {
+    try {
+      const normalized = getAddress(address);
+      if (!seen.has(normalized)) {
+        seen.add(normalized);
+        deduped.push(normalized);
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return deduped;
+};
+
+const getFeedbackClients = (feedback: ReputationFeedbackResult): string[] =>
+  isReputationFeedbackTuple(feedback) ? feedback[0] : feedback.clients;
+
+const resolveReputationScore = async (
+  reputationContract: ReputationContract,
+  parsedRegistryAddress: string,
+  agentId: bigint,
+): Promise<number | null> => {
+  const identityRegistry = getAddress(await reputationContract.getIdentityRegistry());
+  if (identityRegistry !== parsedRegistryAddress) {
+    return null;
+  }
+
+  const feedbackResult = await reputationContract.readAllFeedback(agentId, [], STARRED_TAG, '', false);
+  const feedback = getFeedbackValues(feedbackResult)
+    .filter((entry) => entry.tag1 === undefined || entry.tag1 === STARRED_TAG)
+    .filter((entry) => !entry.isRevoked);
+
+  const clientAddresses = dedupeAddresses(getFeedbackClients(feedbackResult));
+  if (clientAddresses.length) {
+    const summary = getSummaryValue(await reputationContract.getSummary(agentId, clientAddresses, STARRED_TAG, ''));
+    const count = toNumber(summary.count);
+    if (count) {
+      return scaleFixedPoint(summary.summaryValue, summary.summaryValueDecimals);
+    }
+  }
+
+  return averageScores(feedback.map((entry) => scaleFixedPoint(entry.value, entry.valueDecimals)));
 };
 
 const parseAgentRegistry = (agentRegistry: string) => {
@@ -159,22 +310,18 @@ export const resolveAgentIdentity = async ({
       async () => decodeMetadata(await identityContract.getMetadata(BigInt(declaration.agentId), 'uri')),
     ]),
     reputationContract
-      ? callFirst<bigint | number>([
-          async () => await reputationContract.getScore(BigInt(declaration.agentId)),
-          async () => await reputationContract.getReputation(BigInt(declaration.agentId)),
-          async () => await reputationContract.reputationScores(BigInt(declaration.agentId)),
-          async () => await reputationContract.scores(BigInt(declaration.agentId)),
-          async () => await reputationContract.reputations(BigInt(declaration.agentId)),
-        ])
+      ? resolveReputationScore(reputationContract, parsedRegistry.address, BigInt(declaration.agentId))
       : Promise.resolve(null),
   ]);
+
+  const normalizedReputationScore = clampScore(reputationScore ?? null);
 
   const resolved: AgentIdentity = {
     ...fallback,
     owner: owner ?? null,
     metadataUri: metadataUri ?? null,
-    reputationScore: clampScore(reputationScore ?? null),
-    trustLevel: getTrustLevel(clampScore(reputationScore ?? null)),
+    reputationScore: normalizedReputationScore,
+    trustLevel: getTrustLevel(normalizedReputationScore),
   };
 
   cache.set(`${rpcUrl}:${declaration.agentRegistry}:${declaration.agentId}`, {

--- a/packages/evm-module/src/utils/resolve-agent-identity.ts
+++ b/packages/evm-module/src/utils/resolve-agent-identity.ts
@@ -183,26 +183,34 @@ const resolveReputationScore = async (
   parsedRegistryAddress: string,
   agentId: bigint,
 ): Promise<number | null> => {
-  const identityRegistry = getAddress(await reputationContract.getIdentityRegistry());
-  if (identityRegistry !== parsedRegistryAddress) {
+  try {
+    const identityRegistry = getAddress(await reputationContract.getIdentityRegistry());
+    if (identityRegistry !== parsedRegistryAddress) {
+      return null;
+    }
+
+    const feedbackResult = await reputationContract.readAllFeedback(agentId, [], STARRED_TAG, '', false);
+    const feedback = getFeedbackValues(feedbackResult)
+      .filter((entry) => entry.tag1 === undefined || entry.tag1 === STARRED_TAG)
+      .filter((entry) => !entry.isRevoked);
+
+    const clientAddresses = dedupeAddresses(getFeedbackClients(feedbackResult));
+    if (clientAddresses.length) {
+      try {
+        const summary = getSummaryValue(await reputationContract.getSummary(agentId, clientAddresses, STARRED_TAG, ''));
+        const count = toNumber(summary.count);
+        if (count) {
+          return scaleFixedPoint(summary.summaryValue, summary.summaryValueDecimals);
+        }
+      } catch {
+        // Ignore summary lookup failures and fall back to raw feedback averaging.
+      }
+    }
+
+    return averageScores(feedback.map((entry) => scaleFixedPoint(entry.value, entry.valueDecimals)));
+  } catch {
     return null;
   }
-
-  const feedbackResult = await reputationContract.readAllFeedback(agentId, [], STARRED_TAG, '', false);
-  const feedback = getFeedbackValues(feedbackResult)
-    .filter((entry) => entry.tag1 === undefined || entry.tag1 === STARRED_TAG)
-    .filter((entry) => !entry.isRevoked);
-
-  const clientAddresses = dedupeAddresses(getFeedbackClients(feedbackResult));
-  if (clientAddresses.length) {
-    const summary = getSummaryValue(await reputationContract.getSummary(agentId, clientAddresses, STARRED_TAG, ''));
-    const count = toNumber(summary.count);
-    if (count) {
-      return scaleFixedPoint(summary.summaryValue, summary.summaryValueDecimals);
-    }
-  }
-
-  return averageScores(feedback.map((entry) => scaleFixedPoint(entry.value, entry.valueDecimals)));
 };
 
 const parseAgentRegistry = (agentRegistry: string) => {

--- a/packages/types/src/agent-identity.ts
+++ b/packages/types/src/agent-identity.ts
@@ -1,0 +1,15 @@
+export type TrustLevel = 'high' | 'medium' | 'low' | 'unknown';
+
+export interface AgentIdentity {
+  agentId: string;
+  agentRegistry: string;
+  owner: string | null;
+  reputationScore: number | null;
+  metadataUri: string | null;
+  trustLevel: TrustLevel;
+}
+
+export interface AgentIdentityDeclaration {
+  agentId: string;
+  agentRegistry: string;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -12,3 +12,4 @@ export * from './transaction-simulation';
 export * from './account';
 export * from './staking';
 export * from './provider';
+export * from './agent-identity';

--- a/packages/types/src/rpc.ts
+++ b/packages/types/src/rpc.ts
@@ -1,6 +1,7 @@
 import type { TransactionRequest } from 'ethers';
 import type { Avalanche, BitcoinInputUTXO, BitcoinOutputUTXO } from '@avalabs/core-wallets-sdk';
 import type { Caip2ChainId, Hex } from './common';
+import type { AgentIdentity } from './agent-identity';
 import type { JsonRpcError, EthereumProviderError, OptionalDataWithOptionalCause } from '@metamask/rpc-errors';
 import type { BalanceChange, TokenApprovals } from './transaction-simulation';
 import type { TokenWithBalanceBTC } from './balance';
@@ -25,6 +26,7 @@ export enum RpcMethod {
   AVALANCHE_SIGN_MESSAGE = 'avalanche_signMessage',
   AVALANCHE_SEND_TRANSACTION = 'avalanche_sendTransaction',
   AVALANCHE_SIGN_TRANSACTION = 'avalanche_signTransaction',
+  AVALANCHE_DECLARE_AGENT_IDENTITY = 'avalanche_declareAgentIdentity',
 
   /* HVM */
   HVM_SIGN_TRANSACTION = 'hvm_signTransaction',
@@ -201,6 +203,7 @@ export type DisplayData = {
   balanceChange?: BalanceChange;
   tokenApprovals?: TokenApprovals;
   isSimulationSuccessful?: boolean;
+  agentIdentity?: AgentIdentity;
 };
 
 export enum AlertType {

--- a/packages/types/src/rpc.ts
+++ b/packages/types/src/rpc.ts
@@ -1,7 +1,6 @@
 import type { TransactionRequest } from 'ethers';
 import type { Avalanche, BitcoinInputUTXO, BitcoinOutputUTXO } from '@avalabs/core-wallets-sdk';
 import type { Caip2ChainId, Hex } from './common';
-import type { AgentIdentity } from './agent-identity';
 import type { JsonRpcError, EthereumProviderError, OptionalDataWithOptionalCause } from '@metamask/rpc-errors';
 import type { BalanceChange, TokenApprovals } from './transaction-simulation';
 import type { TokenWithBalanceBTC } from './balance';
@@ -203,7 +202,6 @@ export type DisplayData = {
   balanceChange?: BalanceChange;
   tokenApprovals?: TokenApprovals;
   isSimulationSuccessful?: boolean;
-  agentIdentity?: AgentIdentity;
 };
 
 export enum AlertType {


### PR DESCRIPTION
## Summary
- add shared ERC-8004 agent identity types and `avalanche_declareAgentIdentity` to the shared RPC surface
- add EVM-side agent identity resolution, context parsing, and declaration handler wiring
- thread resolved agent identity through EVM sign and transaction approval payloads
- add focused tests for the new handler and approval payload propagation

## Testing
- `pnpm --filter @avalabs/vm-module-types build`
- `pnpm --filter @avalabs/evm-module build`
- `pnpm --filter @avalabs/evm-module exec jest --runInBand src/handlers/avalanche-declare-agent-identity/avalanche-declare-agent-identity.test.ts src/handlers/eth-sign/eth-sign.test.ts src/handlers/eth-send-transaction/eth-send-transaction.test.ts src/handlers/eth-send-transaction-batch/eth-send-transaction-batch.test.ts`

Follow-up to ava-labs/core-extension#809.