### PR TITLE
feat: use Polygon Gas Station API for gas estimation

### DIFF
--- a/.changeset/cozy-actors-float.md
+++ b/.changeset/cozy-actors-float.md
@@ -1,0 +1,10 @@
+---
+'@avalabs/evm-module': patch
+'@avalabs/avalanche-module': patch
+'@avalabs/bitcoin-module': patch
+'@avalabs/hvm-module': patch
+'@avalabs/svm-module': patch
+'@avalabs/vm-module-types': patch
+---
+
+Use polygon gas stations

--- a/packages/evm-module/src/handlers/get-network-fee/get-network-fee.test.ts
+++ b/packages/evm-module/src/handlers/get-network-fee/get-network-fee.test.ts
@@ -194,7 +194,7 @@ describe('get-network-fee', () => {
 
       const fee = await getNetworkFee(amoyParams);
 
-      expect(global.fetch).toHaveBeenCalledWith('https://gasstation-amoy.polygon.technology/');
+      expect(global.fetch).toHaveBeenCalledWith('https://gasstation.polygon.technology/amoy');
       expect(fee.baseFee).toBe(1_000_000_000n);
       expect(fee.isFixedFee).toBe(false);
     });

--- a/packages/evm-module/src/handlers/get-network-fee/get-network-fee.test.ts
+++ b/packages/evm-module/src/handlers/get-network-fee/get-network-fee.test.ts
@@ -140,6 +140,97 @@ describe('get-network-fee', () => {
       displayDecimals: 9,
     });
   });
+  describe('for Polygon', () => {
+    const polygonParams = {
+      ...params,
+      chainId: 137,
+      caipId: 'eip155:137',
+    };
+
+    const gasStationResponse = {
+      safeLow: { maxPriorityFee: 30.0, maxFee: 31.0 },
+      standard: { maxPriorityFee: 33.0, maxFee: 34.0 },
+      fast: { maxPriorityFee: 37.0, maxFee: 38.0 },
+      estimatedBaseFee: 1.0,
+      blockTime: 2,
+      blockNumber: 50555440,
+    };
+
+    it('uses Polygon Gas Station for mainnet', async () => {
+      (global.fetch as jest.Mock).mockImplementationOnce(async () => ({
+        ok: true,
+        json: async () => gasStationResponse,
+      }));
+
+      const fee = await getNetworkFee(polygonParams);
+
+      expect(global.fetch).toHaveBeenCalledWith('https://gasstation.polygon.technology/v2');
+      expect(fee).toEqual({
+        baseFee: 1_000_000_000n,
+        low: {
+          maxFeePerGas: 31_000_000_000n,
+          maxPriorityFeePerGas: 30_000_000_000n,
+        },
+        medium: {
+          maxFeePerGas: 34_000_000_000n,
+          maxPriorityFeePerGas: 33_000_000_000n,
+        },
+        high: {
+          maxFeePerGas: 38_000_000_000n,
+          maxPriorityFeePerGas: 37_000_000_000n,
+        },
+        isFixedFee: false,
+        displayDecimals: 9,
+      });
+    });
+
+    it('uses Polygon Amoy Gas Station for testnet', async () => {
+      const amoyParams = { ...polygonParams, chainId: 80002, caipId: 'eip155:80002' };
+
+      (global.fetch as jest.Mock).mockImplementationOnce(async () => ({
+        ok: true,
+        json: async () => gasStationResponse,
+      }));
+
+      const fee = await getNetworkFee(amoyParams);
+
+      expect(global.fetch).toHaveBeenCalledWith('https://gasstation-amoy.polygon.technology/');
+      expect(fee.baseFee).toBe(1_000_000_000n);
+      expect(fee.isFixedFee).toBe(false);
+    });
+
+    it('falls back to generic EIP-1559 if Gas Station fails', async () => {
+      (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Gas Station unavailable'));
+
+      jest.spyOn(JsonRpcProvider.prototype, 'getBlock').mockImplementationOnce(
+        async () =>
+          ({
+            baseFeePerGas: 1_000_000_000n,
+          }) as Block,
+      );
+
+      const fee = await getNetworkFee(polygonParams);
+
+      expect(fee).toEqual({
+        baseFee: 3_000_000_000n,
+        low: {
+          maxFeePerGas: 3_500_000_000n,
+          maxPriorityFeePerGas: 500_000_000n,
+        },
+        medium: {
+          maxFeePerGas: 5_000_000_000n,
+          maxPriorityFeePerGas: 2_000_000_000n,
+        },
+        high: {
+          maxFeePerGas: 6_000_000_000n,
+          maxPriorityFeePerGas: 3_000_000_000n,
+        },
+        isFixedFee: false,
+        displayDecimals: 9,
+      });
+    });
+  });
+
   it('should return with the correct network fees and default gas multiplier and the fiexed fee is `true` because of the newtork chainId (swimmer)', async () => {
     jest.spyOn(JsonRpcProvider.prototype, 'getBlock').mockImplementationOnce(async () => {
       return {

--- a/packages/evm-module/src/handlers/get-network-fee/get-network-fee.ts
+++ b/packages/evm-module/src/handlers/get-network-fee/get-network-fee.ts
@@ -16,6 +16,55 @@ const BASE_PRIORITY_FEE_WEI = 500000000n; //0.5 GWei
 const isCChain = (chainId: number) =>
   chainId === ChainId.AVALANCHE_TESTNET_ID || chainId === ChainId.AVALANCHE_MAINNET_ID;
 
+const POLYGON_MAINNET_CHAIN_ID = 137;
+const POLYGON_AMOY_CHAIN_ID = 80002;
+
+const isPolygon = (chainId: number) => chainId === POLYGON_MAINNET_CHAIN_ID || chainId === POLYGON_AMOY_CHAIN_ID;
+
+const POLYGON_GAS_STATION_URL: Record<number, string> = {
+  [POLYGON_MAINNET_CHAIN_ID]: 'https://gasstation.polygon.technology/v2',
+  [POLYGON_AMOY_CHAIN_ID]: 'https://gasstation-amoy.polygon.technology/',
+};
+
+type PolygonGasStationResponse = {
+  safeLow: { maxPriorityFee: number; maxFee: number };
+  standard: { maxPriorityFee: number; maxFee: number };
+  fast: { maxPriorityFee: number; maxFee: number };
+  estimatedBaseFee: number;
+};
+
+function gweiToWei(gwei: number): bigint {
+  return BigInt(Math.round(gwei * 1e9));
+}
+
+async function getPolygonGasStationFees(chainId: number): Promise<NetworkFees> {
+  const url = POLYGON_GAS_STATION_URL[chainId];
+  if (!url) throw new Error(`No gas station URL for Polygon chain ${chainId}`);
+
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`Polygon Gas Station returned ${response.status}`);
+
+  const data: PolygonGasStationResponse = await response.json();
+
+  return {
+    baseFee: gweiToWei(data.estimatedBaseFee),
+    low: {
+      maxFeePerGas: gweiToWei(data.safeLow.maxFee),
+      maxPriorityFeePerGas: gweiToWei(data.safeLow.maxPriorityFee),
+    },
+    medium: {
+      maxFeePerGas: gweiToWei(data.standard.maxFee),
+      maxPriorityFeePerGas: gweiToWei(data.standard.maxPriorityFee),
+    },
+    high: {
+      maxFeePerGas: gweiToWei(data.fast.maxFee),
+      maxPriorityFeePerGas: gweiToWei(data.fast.maxPriorityFee),
+    },
+    isFixedFee: false,
+    displayDecimals: 9,
+  };
+}
+
 /**
  * Returns {@link NetworkFees} based on {@link DEFAULT_PRESETS} multipliers.
  * @throws Error if provider does not support eip-1559
@@ -61,6 +110,14 @@ export async function getNetworkFee({
       };
     } catch (err) {
       console.error('eth_suggestPriceOptions call failed, falling back to legacy fee fetching');
+    }
+  }
+
+  if (isPolygon(chainId)) {
+    try {
+      return await getPolygonGasStationFees(chainId);
+    } catch (err) {
+      console.error('Polygon Gas Station call failed, falling back to generic fee fetching');
     }
   }
 

--- a/packages/evm-module/src/handlers/get-network-fee/get-network-fee.ts
+++ b/packages/evm-module/src/handlers/get-network-fee/get-network-fee.ts
@@ -23,7 +23,7 @@ const isPolygon = (chainId: number) => chainId === POLYGON_MAINNET_CHAIN_ID || c
 
 const POLYGON_GAS_STATION_URL: Record<number, string> = {
   [POLYGON_MAINNET_CHAIN_ID]: 'https://gasstation.polygon.technology/v2',
-  [POLYGON_AMOY_CHAIN_ID]: 'https://gasstation-amoy.polygon.technology/',
+  [POLYGON_AMOY_CHAIN_ID]: 'https://gasstation.polygon.technology/amoy',
 };
 
 type PolygonGasStationResponse = {


### PR DESCRIPTION
## Summary

- Replaces the generic EIP-1559 block-based gas estimation with the official [Polygon Gas Station API](https://gasstation.polygon.technology/v2) for Polygon networks
- Covers Polygon Mainnet (chain ID 137) and Amoy testnet (chain ID 80002)
- Falls back to the existing generic EIP-1559 path if the Gas Station API is unavailable
- Mirrors the existing C-Chain `eth_suggestPriceOptions` pattern

## Test plan

- [ ] New `describe('for Polygon')` block in `get-network-fee.test.ts` covers: successful mainnet response, successful Amoy response, fallback to generic EIP-1559 on API failure
- [ ] All 8 tests in `get-network-fee.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)