### PR TITLE
CP-14230: add deriveAddresses batch interface via @avalabs/crypto-sdk

### DIFF
--- a/.changeset/derive-addresses-crypto-sdk.md
+++ b/.changeset/derive-addresses-crypto-sdk.md
@@ -1,0 +1,18 @@
+---
+'@avalabs/avalanche-module': minor
+'@avalabs/bitcoin-module': minor
+'@avalabs/evm-module': minor
+'@avalabs/hvm-module': minor
+'@avalabs/svm-module': minor
+'@avalabs/vm-module-types': minor
+---
+
+feat: add `deriveAddresses` batch interface backed by `@avalabs/crypto-sdk`
+
+Each module now exposes a batch `deriveAddresses(params)` method that
+resolves one public key per `accountIndex` via the `ApprovalController` and
+encodes addresses through `@avalabs/crypto-sdk`'s per-chain batch encoders
+(avalanche / evm / bitcoin / svm). The `hvm-module` keeps interface parity
+with local ed25519 + sha256 encoding since crypto-sdk has no HVM encoder
+yet. Adds `DeriveAddressesParams` / `DeriveAddressesResponse` types and a
+new `deriveAddresses` method on the `Module` interface.

--- a/packages/avalanche-module/package.json
+++ b/packages/avalanche-module/package.json
@@ -28,6 +28,7 @@
     "@avalabs/core-etherscan-sdk": "3.1.0-alpha.87",
     "@avalabs/core-utils-sdk": "3.1.0-alpha.87",
     "@avalabs/core-wallets-sdk": "3.1.0-alpha.87",
+    "@avalabs/crypto-sdk": "0.0.0-ray-crypto-core-20260521183935",
     "@avalabs/glacier-sdk": "3.1.0-alpha.87",
     "@avalabs/types": "3.1.0-alpha.87",
     "@avalabs/vm-module-types": "workspace:*",

--- a/packages/avalanche-module/package.json
+++ b/packages/avalanche-module/package.json
@@ -28,7 +28,7 @@
     "@avalabs/core-etherscan-sdk": "3.1.0-alpha.87",
     "@avalabs/core-utils-sdk": "3.1.0-alpha.87",
     "@avalabs/core-wallets-sdk": "3.1.0-alpha.87",
-    "@avalabs/crypto-sdk": "0.0.0-ray-crypto-core-20260601162312",
+    "@avalabs/crypto-sdk": "1.0.0",
     "@avalabs/glacier-sdk": "3.1.0-alpha.87",
     "@avalabs/types": "3.1.0-alpha.87",
     "@avalabs/vm-module-types": "workspace:*",

--- a/packages/avalanche-module/package.json
+++ b/packages/avalanche-module/package.json
@@ -28,7 +28,7 @@
     "@avalabs/core-etherscan-sdk": "3.1.0-alpha.87",
     "@avalabs/core-utils-sdk": "3.1.0-alpha.87",
     "@avalabs/core-wallets-sdk": "3.1.0-alpha.87",
-    "@avalabs/crypto-sdk": "0.0.0-ray-crypto-core-20260529182526",
+    "@avalabs/crypto-sdk": "0.0.0-ray-crypto-core-20260601162312",
     "@avalabs/glacier-sdk": "3.1.0-alpha.87",
     "@avalabs/types": "3.1.0-alpha.87",
     "@avalabs/vm-module-types": "workspace:*",

--- a/packages/avalanche-module/package.json
+++ b/packages/avalanche-module/package.json
@@ -28,7 +28,7 @@
     "@avalabs/core-etherscan-sdk": "3.1.0-alpha.87",
     "@avalabs/core-utils-sdk": "3.1.0-alpha.87",
     "@avalabs/core-wallets-sdk": "3.1.0-alpha.87",
-    "@avalabs/crypto-sdk": "0.0.0-ray-crypto-core-20260521183935",
+    "@avalabs/crypto-sdk": "0.0.0-ray-crypto-core-20260529182526",
     "@avalabs/glacier-sdk": "3.1.0-alpha.87",
     "@avalabs/types": "3.1.0-alpha.87",
     "@avalabs/vm-module-types": "workspace:*",

--- a/packages/avalanche-module/src/handlers/derive-addresses/derive-addresses.ts
+++ b/packages/avalanche-module/src/handlers/derive-addresses/derive-addresses.ts
@@ -33,7 +33,10 @@ export const deriveAddresses = async (
           derivationPath: paths.CoreEth,
         }),
       ]);
-      return { xp: Buffer.from(xpHex, 'hex'), evm: Buffer.from(evmHex, 'hex') };
+      return {
+        xp: Uint8Array.from(Buffer.from(xpHex, 'hex')),
+        evm: Uint8Array.from(Buffer.from(evmHex, 'hex')),
+      };
     }),
   );
 

--- a/packages/avalanche-module/src/handlers/derive-addresses/derive-addresses.ts
+++ b/packages/avalanche-module/src/handlers/derive-addresses/derive-addresses.ts
@@ -1,0 +1,51 @@
+import type { ApprovalController, DeriveAddressesParams, DeriveAddressesResponse } from '@avalabs/vm-module-types';
+import { NetworkVMType } from '@avalabs/vm-module-types';
+import { deriveAddressesForAvalanche, init } from '@avalabs/crypto-sdk';
+
+import { buildDerivationPath } from '../build-derivation-path/build-derivation-path';
+
+export const deriveAddresses = async (
+  params: DeriveAddressesParams & { approvalController: ApprovalController },
+): Promise<DeriveAddressesResponse> => {
+  const { approvalController, network, secretId, accountIndices, derivationPathType, addressIndex } = params;
+
+  if (accountIndices.length === 0) {
+    return [];
+  }
+
+  await init();
+
+  // crypto-sdk's deriveAddressesForAvalanche needs the X/P pubkey AND the EVM
+  // pubkey (the latter drives the CoreEth bech32 — same path as the EVM module).
+  // The avalanche buildDerivationPath's CoreEth entry already returns that EVM path.
+  const pubkeyPairs = await Promise.all(
+    accountIndices.map(async (accountIndex) => {
+      const paths = buildDerivationPath({ accountIndex, derivationPathType, addressIndex });
+      const [xpHex, evmHex] = await Promise.all([
+        approvalController.requestPublicKey({
+          curve: 'secp256k1',
+          secretId,
+          derivationPath: paths.AVM,
+        }),
+        approvalController.requestPublicKey({
+          curve: 'secp256k1',
+          secretId,
+          derivationPath: paths.CoreEth,
+        }),
+      ]);
+      return { xp: Buffer.from(xpHex, 'hex'), evm: Buffer.from(evmHex, 'hex') };
+    }),
+  );
+
+  const bundles = await deriveAddressesForAvalanche(
+    pubkeyPairs.map((p) => p.xp),
+    pubkeyPairs.map((p) => p.evm),
+    Boolean(network.isTestnet),
+  );
+
+  return bundles.map((b) => ({
+    [NetworkVMType.AVM]: b.x,
+    [NetworkVMType.PVM]: b.p,
+    [NetworkVMType.CoreEth]: b.coreEth,
+  }));
+};

--- a/packages/avalanche-module/src/module.ts
+++ b/packages/avalanche-module/src/module.ts
@@ -4,6 +4,8 @@ import type {
   ApprovalController,
   BuildDerivationPathParams,
   ConstructorParams,
+  DeriveAddressesParams,
+  DeriveAddressesResponse,
   DeriveAddressParams,
   DeriveAddressResponse,
   GetAddressParams,
@@ -28,6 +30,7 @@ import { avalancheSignMessage } from './handlers/avalanche-sign-message/avalanch
 import { avalancheSignTransaction } from './handlers/avalanche-sign-transaction/avalanche-sign-transaction';
 import { buildDerivationPath } from './handlers/build-derivation-path/build-derivation-path';
 import { deriveAddress } from './handlers/derive-address/derive-address';
+import { deriveAddresses } from './handlers/derive-addresses/derive-addresses';
 import { getAddress } from './handlers/get-address/get-address';
 import { getBalances } from './handlers/get-balances/get-balances';
 import { getNetworkFee } from './handlers/get-network-fee/get-network-fee';
@@ -98,6 +101,13 @@ export class AvalancheModule implements Module {
 
   async deriveAddress(params: DeriveAddressParams): Promise<DeriveAddressResponse> {
     return deriveAddress({
+      ...params,
+      approvalController: this.#approvalController,
+    });
+  }
+
+  async deriveAddresses(params: DeriveAddressesParams): Promise<DeriveAddressesResponse> {
+    return deriveAddresses({
       ...params,
       approvalController: this.#approvalController,
     });

--- a/packages/bitcoin-module/package.json
+++ b/packages/bitcoin-module/package.json
@@ -26,6 +26,7 @@
     "@avalabs/core-coingecko-sdk": "3.1.0-alpha.87",
     "@avalabs/core-utils-sdk": "3.1.0-alpha.87",
     "@avalabs/core-wallets-sdk": "3.1.0-alpha.87",
+    "@avalabs/crypto-sdk": "0.0.0-ray-crypto-core-20260521183935",
     "@avalabs/vm-module-types": "workspace:*",
     "@metamask/rpc-errors": "6.3.0",
     "big.js": "6.2.1",

--- a/packages/bitcoin-module/package.json
+++ b/packages/bitcoin-module/package.json
@@ -26,7 +26,7 @@
     "@avalabs/core-coingecko-sdk": "3.1.0-alpha.87",
     "@avalabs/core-utils-sdk": "3.1.0-alpha.87",
     "@avalabs/core-wallets-sdk": "3.1.0-alpha.87",
-    "@avalabs/crypto-sdk": "0.0.0-ray-crypto-core-20260601162312",
+    "@avalabs/crypto-sdk": "1.0.0",
     "@avalabs/vm-module-types": "workspace:*",
     "@metamask/rpc-errors": "6.3.0",
     "big.js": "6.2.1",

--- a/packages/bitcoin-module/package.json
+++ b/packages/bitcoin-module/package.json
@@ -26,7 +26,7 @@
     "@avalabs/core-coingecko-sdk": "3.1.0-alpha.87",
     "@avalabs/core-utils-sdk": "3.1.0-alpha.87",
     "@avalabs/core-wallets-sdk": "3.1.0-alpha.87",
-    "@avalabs/crypto-sdk": "0.0.0-ray-crypto-core-20260529182526",
+    "@avalabs/crypto-sdk": "0.0.0-ray-crypto-core-20260601162312",
     "@avalabs/vm-module-types": "workspace:*",
     "@metamask/rpc-errors": "6.3.0",
     "big.js": "6.2.1",

--- a/packages/bitcoin-module/package.json
+++ b/packages/bitcoin-module/package.json
@@ -26,7 +26,7 @@
     "@avalabs/core-coingecko-sdk": "3.1.0-alpha.87",
     "@avalabs/core-utils-sdk": "3.1.0-alpha.87",
     "@avalabs/core-wallets-sdk": "3.1.0-alpha.87",
-    "@avalabs/crypto-sdk": "0.0.0-ray-crypto-core-20260521183935",
+    "@avalabs/crypto-sdk": "0.0.0-ray-crypto-core-20260529182526",
     "@avalabs/vm-module-types": "workspace:*",
     "@metamask/rpc-errors": "6.3.0",
     "big.js": "6.2.1",

--- a/packages/bitcoin-module/src/handlers/derive-addresses/derive-addresses.ts
+++ b/packages/bitcoin-module/src/handlers/derive-addresses/derive-addresses.ts
@@ -23,7 +23,7 @@ export const deriveAddresses = async (
         secretId,
         derivationPath,
       });
-      return Buffer.from(publicKeyHex, 'hex');
+      return Uint8Array.from(Buffer.from(publicKeyHex, 'hex'));
     }),
   );
 

--- a/packages/bitcoin-module/src/handlers/derive-addresses/derive-addresses.ts
+++ b/packages/bitcoin-module/src/handlers/derive-addresses/derive-addresses.ts
@@ -1,0 +1,33 @@
+import type { ApprovalController, DeriveAddressesParams, DeriveAddressesResponse } from '@avalabs/vm-module-types';
+import { NetworkVMType } from '@avalabs/vm-module-types';
+import { deriveAddressesForBtc, init } from '@avalabs/crypto-sdk';
+
+import { buildDerivationPath } from '../build-derivation-path/build-derivation-path';
+
+export const deriveAddresses = async (
+  params: DeriveAddressesParams & { approvalController: ApprovalController },
+): Promise<DeriveAddressesResponse> => {
+  const { approvalController, network, secretId, accountIndices, derivationPathType } = params;
+
+  if (accountIndices.length === 0) {
+    return [];
+  }
+
+  await init();
+
+  const publicKeys = await Promise.all(
+    accountIndices.map(async (accountIndex) => {
+      const derivationPath = buildDerivationPath({ accountIndex, derivationPathType }).BITCOIN;
+      const publicKeyHex = await approvalController.requestPublicKey({
+        curve: 'secp256k1',
+        secretId,
+        derivationPath,
+      });
+      return Buffer.from(publicKeyHex, 'hex');
+    }),
+  );
+
+  const addresses = await deriveAddressesForBtc(publicKeys, Boolean(network.isTestnet));
+
+  return addresses.map((address) => ({ [NetworkVMType.BITCOIN]: address }));
+};

--- a/packages/bitcoin-module/src/module.test.ts
+++ b/packages/bitcoin-module/src/module.test.ts
@@ -7,6 +7,9 @@ import { devEnv, prodEnv } from './env';
 
 jest.mock('./handlers/get-network-fee/get-network-fee');
 jest.mock('./handlers/get-balances/get-balances');
+// Short-circuit the @avalabs/crypto-wasm peer-resolution chain. None of the
+// tests in this file exercise deriveAddresses, so an empty stub is sufficient.
+jest.mock('@avalabs/crypto-sdk', () => ({}));
 
 describe('bitcoin-module', () => {
   describe('getNetworkFee()', () => {

--- a/packages/bitcoin-module/src/module.ts
+++ b/packages/bitcoin-module/src/module.ts
@@ -11,6 +11,7 @@ import type {
   ApprovalController,
   ConstructorParams,
   DeriveAddressParams,
+  DeriveAddressesParams,
   BuildDerivationPathParams,
   RuntimeParams,
 } from '@avalabs/vm-module-types';
@@ -28,6 +29,7 @@ import type { BitcoinProvider } from '@avalabs/core-wallets-sdk';
 import { getProvider } from './utils/get-provider';
 import { bitcoinSignTransaction } from './handlers/bitcoin-sign-transaction/bitcoin-sign-transaction';
 import { deriveAddress } from './handlers/derive-address/derive-address';
+import { deriveAddresses } from './handlers/derive-addresses/derive-addresses';
 import { buildDerivationPath } from './handlers/build-derivation-path/build-derivation-path';
 
 export class BitcoinModule implements Module {
@@ -60,6 +62,13 @@ export class BitcoinModule implements Module {
 
   deriveAddress(params: DeriveAddressParams) {
     return deriveAddress({
+      ...params,
+      approvalController: this.#approvalController,
+    });
+  }
+
+  deriveAddresses(params: DeriveAddressesParams) {
+    return deriveAddresses({
       ...params,
       approvalController: this.#approvalController,
     });

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -29,7 +29,7 @@
     "@avalabs/core-utils-sdk": "3.1.0-alpha.87",
     "@avalabs/core-chains-sdk": "3.1.0-alpha.87",
     "@avalabs/core-wallets-sdk": "3.1.0-alpha.87",
-    "@avalabs/crypto-sdk": "0.0.0-ray-crypto-core-20260529182526",
+    "@avalabs/crypto-sdk": "0.0.0-ray-crypto-core-20260601162312",
     "@avalabs/glacier-sdk": "3.1.0-alpha.87",
     "@avalabs/types": "3.1.0-alpha.87",
     "@avalabs/vm-module-types": "workspace:*",

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -29,7 +29,7 @@
     "@avalabs/core-utils-sdk": "3.1.0-alpha.87",
     "@avalabs/core-chains-sdk": "3.1.0-alpha.87",
     "@avalabs/core-wallets-sdk": "3.1.0-alpha.87",
-    "@avalabs/crypto-sdk": "0.0.0-ray-crypto-core-20260521183935",
+    "@avalabs/crypto-sdk": "0.0.0-ray-crypto-core-20260529182526",
     "@avalabs/glacier-sdk": "3.1.0-alpha.87",
     "@avalabs/types": "3.1.0-alpha.87",
     "@avalabs/vm-module-types": "workspace:*",

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -29,7 +29,7 @@
     "@avalabs/core-utils-sdk": "3.1.0-alpha.87",
     "@avalabs/core-chains-sdk": "3.1.0-alpha.87",
     "@avalabs/core-wallets-sdk": "3.1.0-alpha.87",
-    "@avalabs/crypto-sdk": "0.0.0-ray-crypto-core-20260601162312",
+    "@avalabs/crypto-sdk": "1.0.0",
     "@avalabs/glacier-sdk": "3.1.0-alpha.87",
     "@avalabs/types": "3.1.0-alpha.87",
     "@avalabs/vm-module-types": "workspace:*",

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -29,6 +29,7 @@
     "@avalabs/core-utils-sdk": "3.1.0-alpha.87",
     "@avalabs/core-chains-sdk": "3.1.0-alpha.87",
     "@avalabs/core-wallets-sdk": "3.1.0-alpha.87",
+    "@avalabs/crypto-sdk": "0.0.0-ray-crypto-core-20260521183935",
     "@avalabs/glacier-sdk": "3.1.0-alpha.87",
     "@avalabs/types": "3.1.0-alpha.87",
     "@avalabs/vm-module-types": "workspace:*",

--- a/packages/evm-module/src/handlers/derive-addresses/derive-addresses.ts
+++ b/packages/evm-module/src/handlers/derive-addresses/derive-addresses.ts
@@ -27,7 +27,7 @@ export const deriveAddresses = async (
         secretId,
         derivationPath,
       });
-      return Buffer.from(publicKeyHex, 'hex');
+      return Uint8Array.from(Buffer.from(publicKeyHex, 'hex'));
     }),
   );
 

--- a/packages/evm-module/src/handlers/derive-addresses/derive-addresses.ts
+++ b/packages/evm-module/src/handlers/derive-addresses/derive-addresses.ts
@@ -1,0 +1,37 @@
+import {
+  NetworkVMType,
+  type ApprovalController,
+  type DeriveAddressesParams,
+  type DeriveAddressesResponse,
+} from '@avalabs/vm-module-types';
+import { deriveAddressesForEvm, init } from '@avalabs/crypto-sdk';
+
+import { buildDerivationPath } from '../build-derivation-path/build-derivation-path';
+
+export const deriveAddresses = async (
+  params: DeriveAddressesParams & { approvalController: ApprovalController },
+): Promise<DeriveAddressesResponse> => {
+  const { approvalController, secretId, accountIndices, derivationPathType } = params;
+
+  if (accountIndices.length === 0) {
+    return [];
+  }
+
+  await init();
+
+  const publicKeys = await Promise.all(
+    accountIndices.map(async (accountIndex) => {
+      const derivationPath = buildDerivationPath({ accountIndex, derivationPathType }).EVM;
+      const publicKeyHex = await approvalController.requestPublicKey({
+        curve: 'secp256k1',
+        secretId,
+        derivationPath,
+      });
+      return Buffer.from(publicKeyHex, 'hex');
+    }),
+  );
+
+  const addresses = await deriveAddressesForEvm(publicKeys);
+
+  return addresses.map((address) => ({ [NetworkVMType.EVM]: address }));
+};

--- a/packages/evm-module/src/module.ts
+++ b/packages/evm-module/src/module.ts
@@ -5,6 +5,8 @@ import {
   type ApprovalController,
   type BuildDerivationPathParams,
   type ConstructorParams,
+  type DeriveAddressesParams,
+  type DeriveAddressesResponse,
   type DeriveAddressParams,
   type DeriveAddressResponse,
   type GetAddressParams,
@@ -28,6 +30,7 @@ import { BLOCKAID_API_KEY } from './constants';
 import { getEnv } from './env';
 import { buildDerivationPath } from './handlers/build-derivation-path/build-derivation-path';
 import { deriveAddress } from './handlers/derive-address/derive-address';
+import { deriveAddresses } from './handlers/derive-addresses/derive-addresses';
 import { ethSendTransactionBatch } from './handlers/eth-send-transaction-batch/eth-send-transaction-batch';
 import { ethSendTransaction } from './handlers/eth-send-transaction/eth-send-transaction';
 import { ethSign } from './handlers/eth-sign/eth-sign';
@@ -89,6 +92,13 @@ export class EvmModule implements Module {
 
   deriveAddress(params: DeriveAddressParams): Promise<DeriveAddressResponse> {
     return deriveAddress({
+      ...params,
+      approvalController: this.#approvalController,
+    });
+  }
+
+  deriveAddresses(params: DeriveAddressesParams): Promise<DeriveAddressesResponse> {
+    return deriveAddresses({
       ...params,
       approvalController: this.#approvalController,
     });

--- a/packages/hvm-module/src/handlers/derive-addresses/derive-addresses.ts
+++ b/packages/hvm-module/src/handlers/derive-addresses/derive-addresses.ts
@@ -1,0 +1,38 @@
+import type { ApprovalController, DeriveAddressesParams, DeriveAddressesResponse } from '@avalabs/vm-module-types';
+import { NetworkVMType } from '@avalabs/vm-module-types';
+import { sha256 } from '@noble/hashes/sha256';
+import { hex } from '@scure/base';
+
+import { buildDerivationPath } from '../build-derivation-path/build-derivation-path';
+
+const ED25519_AUTH_ID = 0x00;
+
+// crypto-sdk has no HVM encoder yet, so this handler keeps interface parity
+// with the other modules but encodes locally using the same logic as
+// derive-address (ed25519 pubkey -> sha256 -> AUTH_ID prefix + 4-byte checksum).
+export const deriveAddresses = async (
+  params: DeriveAddressesParams & { approvalController: ApprovalController },
+): Promise<DeriveAddressesResponse> => {
+  const { approvalController, secretId, accountIndices, derivationPathType } = params;
+
+  if (accountIndices.length === 0) {
+    return [];
+  }
+
+  const addresses = await Promise.all(
+    accountIndices.map(async (accountIndex) => {
+      const derivationPath = buildDerivationPath({ accountIndex, derivationPathType }).HVM;
+      const publicKeyHex = await approvalController.requestPublicKey({
+        curve: 'ed25519',
+        secretId,
+        derivationPath,
+      });
+      const publicKeyBytes = hex.decode(publicKeyHex);
+      const addressBytes = new Uint8Array([ED25519_AUTH_ID, ...sha256(publicKeyBytes)]);
+      const checksum = sha256(addressBytes).slice(-4);
+      return `0x${hex.encode(addressBytes)}${hex.encode(checksum)}`;
+    }),
+  );
+
+  return addresses.map((address) => ({ [NetworkVMType.HVM]: address }));
+};

--- a/packages/hvm-module/src/module.ts
+++ b/packages/hvm-module/src/module.ts
@@ -16,6 +16,7 @@ import {
   RpcMethod,
   type GetAddressParams,
   type DeriveAddressParams,
+  type DeriveAddressesParams,
   type BuildDerivationPathParams,
 } from '@avalabs/vm-module-types';
 
@@ -25,6 +26,7 @@ import { hvmGetBalances } from './handlers/get-balances';
 import { rpcErrors } from '@metamask/rpc-errors';
 import { hvmSign } from './handlers/sign-transaction/sign-transaction';
 import { deriveAddress } from './handlers/derive-address/derive-address';
+import { deriveAddresses } from './handlers/derive-addresses/derive-addresses';
 import { buildDerivationPath } from './handlers/build-derivation-path/build-derivation-path';
 
 export class HvmModule implements Module {
@@ -53,6 +55,13 @@ export class HvmModule implements Module {
 
   deriveAddress(params: DeriveAddressParams) {
     return deriveAddress({
+      ...params,
+      approvalController: this.#approvalController,
+    });
+  }
+
+  deriveAddresses(params: DeriveAddressesParams) {
+    return deriveAddresses({
       ...params,
       approvalController: this.#approvalController,
     });

--- a/packages/svm-module/package.json
+++ b/packages/svm-module/package.json
@@ -26,7 +26,7 @@
     "@avalabs/core-coingecko-sdk": "3.1.0-alpha.87",
     "@avalabs/core-utils-sdk": "3.1.0-alpha.87",
     "@avalabs/core-wallets-sdk": "3.1.0-alpha.87",
-    "@avalabs/crypto-sdk": "0.0.0-ray-crypto-core-20260521183935",
+    "@avalabs/crypto-sdk": "0.0.0-ray-crypto-core-20260529182526",
     "@avalabs/vm-module-types": "workspace:*",
     "@blockaid/client": "0.48.0",
     "@metamask/rpc-errors": "6.3.0",

--- a/packages/svm-module/package.json
+++ b/packages/svm-module/package.json
@@ -26,6 +26,7 @@
     "@avalabs/core-coingecko-sdk": "3.1.0-alpha.87",
     "@avalabs/core-utils-sdk": "3.1.0-alpha.87",
     "@avalabs/core-wallets-sdk": "3.1.0-alpha.87",
+    "@avalabs/crypto-sdk": "0.0.0-ray-crypto-core-20260521183935",
     "@avalabs/vm-module-types": "workspace:*",
     "@blockaid/client": "0.48.0",
     "@metamask/rpc-errors": "6.3.0",

--- a/packages/svm-module/package.json
+++ b/packages/svm-module/package.json
@@ -26,7 +26,7 @@
     "@avalabs/core-coingecko-sdk": "3.1.0-alpha.87",
     "@avalabs/core-utils-sdk": "3.1.0-alpha.87",
     "@avalabs/core-wallets-sdk": "3.1.0-alpha.87",
-    "@avalabs/crypto-sdk": "0.0.0-ray-crypto-core-20260601162312",
+    "@avalabs/crypto-sdk": "1.0.0",
     "@avalabs/vm-module-types": "workspace:*",
     "@blockaid/client": "0.48.0",
     "@metamask/rpc-errors": "6.3.0",

--- a/packages/svm-module/package.json
+++ b/packages/svm-module/package.json
@@ -26,7 +26,7 @@
     "@avalabs/core-coingecko-sdk": "3.1.0-alpha.87",
     "@avalabs/core-utils-sdk": "3.1.0-alpha.87",
     "@avalabs/core-wallets-sdk": "3.1.0-alpha.87",
-    "@avalabs/crypto-sdk": "0.0.0-ray-crypto-core-20260529182526",
+    "@avalabs/crypto-sdk": "0.0.0-ray-crypto-core-20260601162312",
     "@avalabs/vm-module-types": "workspace:*",
     "@blockaid/client": "0.48.0",
     "@metamask/rpc-errors": "6.3.0",

--- a/packages/svm-module/src/handlers/derive-addresses/derive-addresses.ts
+++ b/packages/svm-module/src/handlers/derive-addresses/derive-addresses.ts
@@ -23,7 +23,7 @@ export const deriveAddresses = async (
         secretId,
         derivationPath,
       });
-      return Buffer.from(publicKeyHex, 'hex');
+      return Uint8Array.from(Buffer.from(publicKeyHex, 'hex'));
     }),
   );
 

--- a/packages/svm-module/src/handlers/derive-addresses/derive-addresses.ts
+++ b/packages/svm-module/src/handlers/derive-addresses/derive-addresses.ts
@@ -1,0 +1,33 @@
+import type { ApprovalController, DeriveAddressesParams, DeriveAddressesResponse } from '@avalabs/vm-module-types';
+import { NetworkVMType } from '@avalabs/vm-module-types';
+import { deriveAddressesForSvm, init } from '@avalabs/crypto-sdk';
+
+import { buildDerivationPath } from '../build-derivation-path/build-derivation-path';
+
+export const deriveAddresses = async (
+  params: DeriveAddressesParams & { approvalController: ApprovalController },
+): Promise<DeriveAddressesResponse> => {
+  const { approvalController, secretId, accountIndices, derivationPathType } = params;
+
+  if (accountIndices.length === 0) {
+    return [];
+  }
+
+  await init();
+
+  const publicKeys = await Promise.all(
+    accountIndices.map(async (accountIndex) => {
+      const derivationPath = buildDerivationPath({ accountIndex, derivationPathType }).SVM;
+      const publicKeyHex = await approvalController.requestPublicKey({
+        curve: 'ed25519',
+        secretId,
+        derivationPath,
+      });
+      return Buffer.from(publicKeyHex, 'hex');
+    }),
+  );
+
+  const addresses = await deriveAddressesForSvm(publicKeys);
+
+  return addresses.map((address) => ({ [NetworkVMType.SVM]: address }));
+};

--- a/packages/svm-module/src/handlers/derive-addresses/index.ts
+++ b/packages/svm-module/src/handlers/derive-addresses/index.ts
@@ -1,0 +1,1 @@
+export * from './derive-addresses';

--- a/packages/svm-module/src/module.test.ts
+++ b/packages/svm-module/src/module.test.ts
@@ -23,6 +23,9 @@ jest.mock('./handlers/get-network-fee');
 jest.mock('./handlers/get-tokens');
 jest.mock('./handlers/get-transaction-history');
 jest.mock('./handlers/sign-and-send-transaction');
+// Short-circuit the @avalabs/crypto-wasm peer-resolution chain. None of the
+// tests in this file exercise deriveAddresses, so an empty stub is sufficient.
+jest.mock('@avalabs/crypto-sdk', () => ({}));
 
 describe('SVM Module', () => {
   const svm = new SvmModule({

--- a/packages/svm-module/src/module.ts
+++ b/packages/svm-module/src/module.ts
@@ -5,6 +5,7 @@ import {
   type ApprovalController,
   type BuildDerivationPathParams,
   type ConstructorParams,
+  type DeriveAddressesParams,
   type DeriveAddressParams,
   type GetBalancesParams,
   type GetTransactionHistory,
@@ -22,6 +23,7 @@ import { TokenService } from '@internal/utils';
 import ManifestJson from '../manifest.json';
 import { getEnv } from './env';
 import { deriveAddress } from './handlers/derive-address';
+import { deriveAddresses } from './handlers/derive-addresses';
 import { buildDerivationPath } from './handlers/build-derivation-path';
 import { getNetworkFee } from './handlers/get-network-fee';
 import { getTokens } from './handlers/get-tokens';
@@ -77,6 +79,13 @@ export class SvmModule implements Module {
 
   deriveAddress(params: DeriveAddressParams) {
     return deriveAddress({
+      ...params,
+      approvalController: this.#approvalController,
+    });
+  }
+
+  deriveAddresses(params: DeriveAddressesParams) {
+    return deriveAddresses({
       ...params,
       approvalController: this.#approvalController,
     });

--- a/packages/types/src/account.ts
+++ b/packages/types/src/account.ts
@@ -49,6 +49,16 @@ export type DeriveAddressParams = SimpleDeriveAddressParams | DetailedDeriveAddr
 
 export type DeriveAddressResponse = Partial<Record<NetworkVMType, string>>;
 
+export type DeriveAddressesParams = {
+  network: Omit<Network, 'tokens'>;
+  secretId: string;
+  accountIndices: number[];
+  derivationPathType: DerivationPathType;
+  addressIndex?: number;
+};
+
+export type DeriveAddressesResponse = DeriveAddressResponse[];
+
 export type DerivationPathType = 'bip44' | 'ledger_live';
 export type BuildDerivationPathParams = {
   accountIndex: number;

--- a/packages/types/src/module.ts
+++ b/packages/types/src/module.ts
@@ -2,6 +2,8 @@ import type { Avalanche, BitcoinProvider, JsonRpcBatchInternal, SolanaProvider }
 import type {
   BuildDerivationPathParams,
   BuildDerivationPathResponse,
+  DeriveAddressesParams,
+  DeriveAddressesResponse,
   DeriveAddressParams,
   DeriveAddressResponse,
   GetAddressParams,
@@ -50,6 +52,7 @@ export interface Module {
    */
   getAddress: (params: GetAddressParams) => Promise<GetAddressResponse>;
   deriveAddress: (params: DeriveAddressParams) => Promise<DeriveAddressResponse>;
+  deriveAddresses: (params: DeriveAddressesParams) => Promise<DeriveAddressesResponse>;
   buildDerivationPath: (params: BuildDerivationPathParams) => BuildDerivationPathResponse;
   getTokens: (network: Network) => Promise<NetworkContractToken[]>;
   onRpcRequest: (request: RpcRequest, chain: Network) => Promise<RpcResponse>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,8 +160,8 @@ importers:
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87(@solana/sysvars@2.1.0(typescript@5.8.2))(big.js@6.2.1)(bn.js@5.2.1)(ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10))(node-fetch@2.7.0)(react@18.3.1)(typescript@5.8.2)
       '@avalabs/crypto-sdk':
-        specifier: 0.0.0-ray-crypto-core-20260529182526
-        version: 0.0.0-ray-crypto-core-20260529182526
+        specifier: 0.0.0-ray-crypto-core-20260601162312
+        version: 0.0.0-ray-crypto-core-20260601162312
       '@avalabs/glacier-sdk':
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87
@@ -224,8 +224,8 @@ importers:
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87(@solana/sysvars@2.1.0(typescript@5.8.2))(big.js@6.2.1)(bn.js@5.2.1)(ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10))(node-fetch@2.7.0)(react@18.3.1)(typescript@5.8.2)
       '@avalabs/crypto-sdk':
-        specifier: 0.0.0-ray-crypto-core-20260529182526
-        version: 0.0.0-ray-crypto-core-20260529182526
+        specifier: 0.0.0-ray-crypto-core-20260601162312
+        version: 0.0.0-ray-crypto-core-20260601162312
       '@avalabs/vm-module-types':
         specifier: workspace:*
         version: link:../types
@@ -291,8 +291,8 @@ importers:
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87(@solana/sysvars@2.1.0(typescript@5.8.2))(big.js@6.2.1)(bn.js@5.2.1)(ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10))(node-fetch@2.7.0)(react@18.3.1)(typescript@5.8.2)
       '@avalabs/crypto-sdk':
-        specifier: 0.0.0-ray-crypto-core-20260529182526
-        version: 0.0.0-ray-crypto-core-20260529182526
+        specifier: 0.0.0-ray-crypto-core-20260601162312
+        version: 0.0.0-ray-crypto-core-20260601162312
       '@avalabs/glacier-sdk':
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87
@@ -434,8 +434,8 @@ importers:
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87(@solana/sysvars@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))(big.js@6.2.1)(bn.js@5.2.2)(ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(node-fetch@2.7.0)(react@18.3.1)(typescript@5.8.2)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@avalabs/crypto-sdk':
-        specifier: 0.0.0-ray-crypto-core-20260529182526
-        version: 0.0.0-ray-crypto-core-20260529182526
+        specifier: 0.0.0-ray-crypto-core-20260601162312
+        version: 0.0.0-ray-crypto-core-20260601162312
       '@avalabs/vm-module-types':
         specifier: workspace:*
         version: link:../types
@@ -590,12 +590,12 @@ packages:
     peerDependencies:
       ethers: ^6.7.1
 
-  '@avalabs/crypto-sdk@0.0.0-ray-crypto-core-20260529182526':
-    resolution: {integrity: sha512-emPrAsoPGXpXCxGQO+4u9jsIjPM6dnjFIXbPGPh2iLGdKw2olOL1hPWJI85mFvIwUgLML1ljlMnvm2i6EwBaQg==}
+  '@avalabs/crypto-sdk@0.0.0-ray-crypto-core-20260601162312':
+    resolution: {integrity: sha512-p8QAwZCK7SVEmzgCJgChWeWHUWZU69HlzMoFENOGbcr7Rgt7sYL8h+j9ANVw1Pq056pHOebmsvmeE0dpnPo/3A==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      '@avalabs/crypto-nitro': 0.0.0-ray-crypto-core-20260529182526
-      '@avalabs/crypto-wasm': 0.0.0-ray-crypto-core-20260529182526
+      '@avalabs/crypto-nitro': 0.0.0-ray-crypto-core-20260601162312
+      '@avalabs/crypto-wasm': 0.0.0-ray-crypto-core-20260601162312
     peerDependenciesMeta:
       '@avalabs/crypto-nitro':
         optional: true
@@ -6577,7 +6577,7 @@ snapshots:
       - typescript
       - ws
 
-  '@avalabs/crypto-sdk@0.0.0-ray-crypto-core-20260529182526': {}
+  '@avalabs/crypto-sdk@0.0.0-ray-crypto-core-20260601162312': {}
 
   '@avalabs/glacier-sdk@3.1.0-alpha.61': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,8 +160,8 @@ importers:
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87(@solana/sysvars@2.1.0(typescript@5.8.2))(big.js@6.2.1)(bn.js@5.2.1)(ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10))(node-fetch@2.7.0)(react@18.3.1)(typescript@5.8.2)
       '@avalabs/crypto-sdk':
-        specifier: 0.0.0-ray-crypto-core-20260601162312
-        version: 0.0.0-ray-crypto-core-20260601162312
+        specifier: 1.0.0
+        version: 1.0.0
       '@avalabs/glacier-sdk':
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87
@@ -224,8 +224,8 @@ importers:
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87(@solana/sysvars@2.1.0(typescript@5.8.2))(big.js@6.2.1)(bn.js@5.2.1)(ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10))(node-fetch@2.7.0)(react@18.3.1)(typescript@5.8.2)
       '@avalabs/crypto-sdk':
-        specifier: 0.0.0-ray-crypto-core-20260601162312
-        version: 0.0.0-ray-crypto-core-20260601162312
+        specifier: 1.0.0
+        version: 1.0.0
       '@avalabs/vm-module-types':
         specifier: workspace:*
         version: link:../types
@@ -291,8 +291,8 @@ importers:
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87(@solana/sysvars@2.1.0(typescript@5.8.2))(big.js@6.2.1)(bn.js@5.2.1)(ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10))(node-fetch@2.7.0)(react@18.3.1)(typescript@5.8.2)
       '@avalabs/crypto-sdk':
-        specifier: 0.0.0-ray-crypto-core-20260601162312
-        version: 0.0.0-ray-crypto-core-20260601162312
+        specifier: 1.0.0
+        version: 1.0.0
       '@avalabs/glacier-sdk':
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87
@@ -434,8 +434,8 @@ importers:
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87(@solana/sysvars@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))(big.js@6.2.1)(bn.js@5.2.2)(ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(node-fetch@2.7.0)(react@18.3.1)(typescript@5.8.2)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@avalabs/crypto-sdk':
-        specifier: 0.0.0-ray-crypto-core-20260601162312
-        version: 0.0.0-ray-crypto-core-20260601162312
+        specifier: 1.0.0
+        version: 1.0.0
       '@avalabs/vm-module-types':
         specifier: workspace:*
         version: link:../types
@@ -590,12 +590,12 @@ packages:
     peerDependencies:
       ethers: ^6.7.1
 
-  '@avalabs/crypto-sdk@0.0.0-ray-crypto-core-20260601162312':
-    resolution: {integrity: sha512-p8QAwZCK7SVEmzgCJgChWeWHUWZU69HlzMoFENOGbcr7Rgt7sYL8h+j9ANVw1Pq056pHOebmsvmeE0dpnPo/3A==}
+  '@avalabs/crypto-sdk@1.0.0':
+    resolution: {integrity: sha512-2klBU8O8FhNKnQs511eJjCWOzM1XcWsSmK1KtXrGl4qAMhHnat8/Uvs0KQHphIZfCGGkOFe25LrekacP5p6Kpg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      '@avalabs/crypto-nitro': 0.0.0-ray-crypto-core-20260601162312
-      '@avalabs/crypto-wasm': 0.0.0-ray-crypto-core-20260601162312
+      '@avalabs/crypto-nitro': 0.3.0
+      '@avalabs/crypto-wasm': 0.3.0
     peerDependenciesMeta:
       '@avalabs/crypto-nitro':
         optional: true
@@ -6577,7 +6577,7 @@ snapshots:
       - typescript
       - ws
 
-  '@avalabs/crypto-sdk@0.0.0-ray-crypto-core-20260601162312': {}
+  '@avalabs/crypto-sdk@1.0.0': {}
 
   '@avalabs/glacier-sdk@3.1.0-alpha.61': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       '@avalabs/core-wallets-sdk':
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87(@solana/sysvars@2.1.0(typescript@5.8.2))(big.js@6.2.1)(bn.js@5.2.1)(ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10))(node-fetch@2.7.0)(react@18.3.1)(typescript@5.8.2)
+      '@avalabs/crypto-sdk':
+        specifier: 0.0.0-ray-crypto-core-20260521183935
+        version: 0.0.0-ray-crypto-core-20260521183935
       '@avalabs/glacier-sdk':
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87
@@ -220,6 +223,9 @@ importers:
       '@avalabs/core-wallets-sdk':
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87(@solana/sysvars@2.1.0(typescript@5.8.2))(big.js@6.2.1)(bn.js@5.2.1)(ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10))(node-fetch@2.7.0)(react@18.3.1)(typescript@5.8.2)
+      '@avalabs/crypto-sdk':
+        specifier: 0.0.0-ray-crypto-core-20260521183935
+        version: 0.0.0-ray-crypto-core-20260521183935
       '@avalabs/vm-module-types':
         specifier: workspace:*
         version: link:../types
@@ -284,6 +290,9 @@ importers:
       '@avalabs/core-wallets-sdk':
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87(@solana/sysvars@2.1.0(typescript@5.8.2))(big.js@6.2.1)(bn.js@5.2.1)(ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10))(node-fetch@2.7.0)(react@18.3.1)(typescript@5.8.2)
+      '@avalabs/crypto-sdk':
+        specifier: 0.0.0-ray-crypto-core-20260521183935
+        version: 0.0.0-ray-crypto-core-20260521183935
       '@avalabs/glacier-sdk':
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87
@@ -424,6 +433,9 @@ importers:
       '@avalabs/core-wallets-sdk':
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87(@solana/sysvars@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))(big.js@6.2.1)(bn.js@5.2.2)(ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(node-fetch@2.7.0)(react@18.3.1)(typescript@5.8.2)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@avalabs/crypto-sdk':
+        specifier: 0.0.0-ray-crypto-core-20260521183935
+        version: 0.0.0-ray-crypto-core-20260521183935
       '@avalabs/vm-module-types':
         specifier: workspace:*
         version: link:../types
@@ -577,6 +589,18 @@ packages:
     resolution: {integrity: sha512-Jy1tsbIgsvKsIHAjmoaTRaGeWVaIbG2Sh0qznY74CahGmEuKEzFSmCwM6Ad6ZGDjF/uEO8ip6E++kDMjDLl6wg==}
     peerDependencies:
       ethers: ^6.7.1
+
+  '@avalabs/crypto-sdk@0.0.0-ray-crypto-core-20260521183935':
+    resolution: {integrity: sha512-0bHdSD3pcItBbh32Fxj6QepqEIab8dDeFYdnKlufbzPsPOTH3vN26ILr8JXtNzDncUjjBqFbTQe5Vr0/fTE4JA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      '@avalabs/crypto-nitro': 0.0.0-ray-crypto-core-20260521183935
+      '@avalabs/crypto-wasm': 0.0.0-ray-crypto-core-20260521183935
+    peerDependenciesMeta:
+      '@avalabs/crypto-nitro':
+        optional: true
+      '@avalabs/crypto-wasm':
+        optional: true
 
   '@avalabs/glacier-sdk@3.1.0-alpha.61':
     resolution: {integrity: sha512-S+BcxSZ+ETeE7OpQgWDi9mbKjmrqZLPDeut7CCMnUfoY6Y1CgMcc8brx2ugr5S9vA9X+L66YrJgiew5YCYp3Dw==}
@@ -6552,6 +6576,8 @@ snapshots:
       - supports-color
       - typescript
       - ws
+
+  '@avalabs/crypto-sdk@0.0.0-ray-crypto-core-20260521183935': {}
 
   '@avalabs/glacier-sdk@3.1.0-alpha.61': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,8 +160,8 @@ importers:
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87(@solana/sysvars@2.1.0(typescript@5.8.2))(big.js@6.2.1)(bn.js@5.2.1)(ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10))(node-fetch@2.7.0)(react@18.3.1)(typescript@5.8.2)
       '@avalabs/crypto-sdk':
-        specifier: 0.0.0-ray-crypto-core-20260521183935
-        version: 0.0.0-ray-crypto-core-20260521183935
+        specifier: 0.0.0-ray-crypto-core-20260529182526
+        version: 0.0.0-ray-crypto-core-20260529182526
       '@avalabs/glacier-sdk':
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87
@@ -224,8 +224,8 @@ importers:
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87(@solana/sysvars@2.1.0(typescript@5.8.2))(big.js@6.2.1)(bn.js@5.2.1)(ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10))(node-fetch@2.7.0)(react@18.3.1)(typescript@5.8.2)
       '@avalabs/crypto-sdk':
-        specifier: 0.0.0-ray-crypto-core-20260521183935
-        version: 0.0.0-ray-crypto-core-20260521183935
+        specifier: 0.0.0-ray-crypto-core-20260529182526
+        version: 0.0.0-ray-crypto-core-20260529182526
       '@avalabs/vm-module-types':
         specifier: workspace:*
         version: link:../types
@@ -291,8 +291,8 @@ importers:
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87(@solana/sysvars@2.1.0(typescript@5.8.2))(big.js@6.2.1)(bn.js@5.2.1)(ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10))(node-fetch@2.7.0)(react@18.3.1)(typescript@5.8.2)
       '@avalabs/crypto-sdk':
-        specifier: 0.0.0-ray-crypto-core-20260521183935
-        version: 0.0.0-ray-crypto-core-20260521183935
+        specifier: 0.0.0-ray-crypto-core-20260529182526
+        version: 0.0.0-ray-crypto-core-20260529182526
       '@avalabs/glacier-sdk':
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87
@@ -434,8 +434,8 @@ importers:
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87(@solana/sysvars@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))(big.js@6.2.1)(bn.js@5.2.2)(ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(node-fetch@2.7.0)(react@18.3.1)(typescript@5.8.2)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@avalabs/crypto-sdk':
-        specifier: 0.0.0-ray-crypto-core-20260521183935
-        version: 0.0.0-ray-crypto-core-20260521183935
+        specifier: 0.0.0-ray-crypto-core-20260529182526
+        version: 0.0.0-ray-crypto-core-20260529182526
       '@avalabs/vm-module-types':
         specifier: workspace:*
         version: link:../types
@@ -590,12 +590,12 @@ packages:
     peerDependencies:
       ethers: ^6.7.1
 
-  '@avalabs/crypto-sdk@0.0.0-ray-crypto-core-20260521183935':
-    resolution: {integrity: sha512-0bHdSD3pcItBbh32Fxj6QepqEIab8dDeFYdnKlufbzPsPOTH3vN26ILr8JXtNzDncUjjBqFbTQe5Vr0/fTE4JA==}
+  '@avalabs/crypto-sdk@0.0.0-ray-crypto-core-20260529182526':
+    resolution: {integrity: sha512-emPrAsoPGXpXCxGQO+4u9jsIjPM6dnjFIXbPGPh2iLGdKw2olOL1hPWJI85mFvIwUgLML1ljlMnvm2i6EwBaQg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      '@avalabs/crypto-nitro': 0.0.0-ray-crypto-core-20260521183935
-      '@avalabs/crypto-wasm': 0.0.0-ray-crypto-core-20260521183935
+      '@avalabs/crypto-nitro': 0.0.0-ray-crypto-core-20260529182526
+      '@avalabs/crypto-wasm': 0.0.0-ray-crypto-core-20260529182526
     peerDependenciesMeta:
       '@avalabs/crypto-nitro':
         optional: true
@@ -6577,7 +6577,7 @@ snapshots:
       - typescript
       - ws
 
-  '@avalabs/crypto-sdk@0.0.0-ray-crypto-core-20260521183935': {}
+  '@avalabs/crypto-sdk@0.0.0-ray-crypto-core-20260529182526': {}
 
   '@avalabs/glacier-sdk@3.1.0-alpha.61': {}
 


### PR DESCRIPTION
## Summary

- Adds a new `deriveAddresses(params)` method to every VM module that batch-resolves addresses for multiple `accountIndices` in one call. Public keys are requested via `ApprovalController` (one per index, with the appropriate derivation path), then encoded through `@avalabs/crypto-sdk`'s per-chain batch encoders.
- avalanche/evm/bitcoin/svm modules route through crypto-sdk (`deriveAddressesForAvalanche` / `ForEvm` / `ForBtc` / `ForSvm`). hvm-module keeps interface parity but encodes locally with ed25519+sha256 since crypto-sdk doesn't expose an HVM encoder yet.
- New types `DeriveAddressesParams` / `DeriveAddressesResponse` in `@avalabs/vm-module-types`; `deriveAddresses` added to the `Module` interface. Minor changeset covers all 6 packages (they share a `fixed` group).