### PR TITLE
fix: removed multiContractAddress from the getProvider call

### DIFF
--- a/.changeset/fix-dapp-ethcall-multicall-aggregation.md
+++ b/.changeset/fix-dapp-ethcall-multicall-aggregation.md
@@ -1,0 +1,5 @@
+---
+"@avalabs/evm-module": patch
+---
+
+fix: stop routing forwarded dApp `eth_call`s through Multicall3 aggregation

--- a/packages/evm-module/src/handlers/forward-to-rpc-node/forward-to-rpc-node.test.ts
+++ b/packages/evm-module/src/handlers/forward-to-rpc-node/forward-to-rpc-node.test.ts
@@ -6,7 +6,7 @@ import { NetworkVMType, RpcMethod } from '@avalabs/vm-module-types';
 jest.mock('../../utils/get-provider');
 jest.mock('@metamask/rpc-errors', () => ({
   rpcErrors: {
-    internal: jest.fn().mockImplementation((message) => ({ error: `mocked error: ${message}` })),
+    internal: jest.fn().mockImplementation((opts) => ({ error: opts })),
   },
 }));
 
@@ -56,11 +56,35 @@ describe('forwardToRpcNode', () => {
       chainId: network.chainId,
       chainName: network.chainName,
       rpcUrl: network.rpcUrl,
-      multiContractAddress: undefined,
       pollingInterval: 1000,
+      customRpcHeaders: undefined,
     });
     expect(mockProvider.send).toHaveBeenCalledWith(request.method, request.params);
     expect(result).toEqual({ result: expectedResult });
+  });
+
+  it('does NOT enable Multicall3 aggregation (would rewrite msg.sender and break caller-dependent reads)', async () => {
+    const request = {
+      method: 'eth_call' as RpcMethod,
+      params: [{ from: '0xabc', to: '0xdef', data: '0xfc6f7865' }, 'latest'],
+      requestId: 'requestId',
+      sessionId: 'sessionId',
+      chainId: 'eip155:1',
+      dappInfo: { name: 'some dapp', url: 'some url', icon: 'some icon' },
+    };
+
+    // network carries a multicall utility address — it must NOT be forwarded to the provider.
+    const networkWithMulticall = {
+      ...network,
+      utilityAddresses: { multicall: '0xcA11bde05977b3631167028862bE2a173976CA11' },
+    };
+
+    mockProvider.send.mockResolvedValue('0x1');
+
+    await forwardToRpcNode(request, networkWithMulticall);
+
+    const passedParams = (getProvider as jest.Mock).mock.calls[0][0];
+    expect(passedParams).not.toHaveProperty('multiContractAddress');
   });
 
   it('should handle errors and return a formatted error response', async () => {
@@ -83,8 +107,40 @@ describe('forwardToRpcNode', () => {
 
     const result = await forwardToRpcNode(request, network);
 
+    // No structured JSON-RPC payload -> fall back to a generic internal error.
     expect(rpcErrors.internal).toHaveBeenCalledWith(error.message);
     expect(result).toHaveProperty('error');
-    expect(result.error).toEqual({ error: `mocked error: ${error.message}` });
+  });
+
+  it('relays the node JSON-RPC error verbatim (code + message + revert data) for reverted calls', async () => {
+    const request = {
+      method: 'eth_call' as RpcMethod,
+      params: [{ to: '0x0', data: '0x' }, 'latest'],
+      requestId: 'requestId',
+      sessionId: 'sessionId',
+      chainId: 'eip155:1',
+      dappInfo: {
+        name: 'some dapp',
+        url: 'some url',
+        icon: 'some icon',
+      },
+    };
+
+    // Shape ethers v6 throws for a reverted eth_call: the raw node error
+    // (code 3 = execution reverted, with the revert bytes) lives under `info.error`.
+    const nodeError = {
+      code: 3,
+      message: 'execution reverted: Multicall3: call failed',
+      data: '0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000174d756c746963616c6c333a2063616c6c206661696c6564000000000000000000',
+    };
+    const error = Object.assign(new Error('execution reverted'), { info: { error: nodeError } });
+
+    mockProvider.send.mockRejectedValue(error);
+
+    const result = await forwardToRpcNode(request, network);
+
+    // Forwarded as-is — NOT re-wrapped as -32603 — so dApps decode the revert like a direct RPC connection.
+    expect(rpcErrors.internal).not.toHaveBeenCalled();
+    expect(result).toEqual({ error: nodeError });
   });
 });

--- a/packages/evm-module/src/handlers/forward-to-rpc-node/forward-to-rpc-node.ts
+++ b/packages/evm-module/src/handlers/forward-to-rpc-node/forward-to-rpc-node.ts
@@ -4,11 +4,18 @@ import { getProvider } from '../../utils/get-provider';
 
 export const forwardToRpcNode = async (request: RpcRequest, network: Network) => {
   try {
+    // IMPORTANT: do NOT pass `multiContractAddress` here. It makes the provider
+    // transparently re-route eth_calls through Multicall3's `aggregate`, which
+    // rewrites `msg.sender` to the Multicall3 contract. For dApp reads that depend
+    // on the caller (e.g. Uniswap-style `collect`, permit/allowance checks,
+    // owner-gated views) that breaks the call — it reverts as "Multicall3: call
+    // failed" even though the same call succeeds as a direct eth_call with the
+    // dApp-provided `from`. We are a verbatim passthrough for dApp requests, so
+    // each call must hit the node as-is to preserve caller semantics.
     const provider = await getProvider({
       chainId: network.chainId,
       chainName: network.chainName,
       rpcUrl: network.rpcUrl,
-      multiContractAddress: network.utilityAddresses?.multicall,
       pollingInterval: 1000,
       customRpcHeaders: network.customRpcHeaders,
     });
@@ -16,9 +23,20 @@ export const forwardToRpcNode = async (request: RpcRequest, network: Network) =>
     const response = await provider.send(request.method, request.params as unknown[]);
     return { result: response };
   } catch (error) {
-    // extracting the error message based on the error object structure from ethers lib
+    // For read methods we are a transparent RPC passthrough, so relay the node's
+    // original JSON-RPC error verbatim — its `code` (e.g. 3 = execution reverted),
+    // `message` and revert `data`. ethers stores that raw payload under
+    // `error.info.error` for a reverted call. Re-coding it as a generic internal
+    // error (-32603) or stripping `data`/`code` makes dApps treat an *expected*
+    // revert (e.g. eth_call/eth_estimateGas fee & quote simulations) as a fatal
+    // failure instead of decoding the revert reason like a direct RPC connection
+    // would.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const message = (error as any).info?.error?.message || (error as any).error?.message || (error as Error).message;
-    return { error: rpcErrors.internal(message) };
+    const rpcError = (error as any).info?.error ?? (error as any).error;
+    if (rpcError && typeof rpcError.code === 'number') {
+      return { error: rpcError };
+    }
+
+    return { error: rpcErrors.internal((error as Error).message) };
   }
 };


### PR DESCRIPTION
- Core was silently routing all forwarded dApp `eth_calls` through Multicall3, corrupting `msg.sender` for any caller-dependent read (Uniswap-style collect, permit/allowance checks, owner-gated views), not Pangolin-specific
- For the Pangolin `PNG-AVAX` pool specifically, the position's fee read is a collect(...) simulation with from = owner. Wrapped in Multicall3, msg.sender became the Multicall3 contract instead of the owner, so the `isAuthorizedForToken` check failed and the call reverted with `Multicall3: call failed`
- Removed multiContractAddress from the getProvider call in forwardToRpcNode, so forwarded dApp `eth_calls` are no longer re-routed through Multicall3 aggregate (which rewrote msg.sender). Each call now hits the node as-is, preserving the dApp-provided from. The other handlers (e.g. `eth_sendTransaction` gas simulation) keep multiContractAddress intentionally

## Fix
Confirmed fix on https://app.pangolin.exchange/pool

https://github.com/user-attachments/assets/f2de2d23-dcd7-4fb5-b93f-436709ebaf19

