### PR TITLE
fix: improve blockaid warning validation

### DIFF
--- a/.changeset/blockaid-error-no-warning.md
+++ b/.changeset/blockaid-error-no-warning.md
@@ -1,0 +1,5 @@
+---
+'@avalabs/evm-module': patch
+---
+
+Only surface a Blockaid transaction warning when the scan returns a genuine Warning or Malicious verdict

--- a/packages/evm-module/src/handlers/eth-send-transaction-batch/eth-send-transaction-batch.test.ts
+++ b/packages/evm-module/src/handlers/eth-send-transaction-batch/eth-send-transaction-batch.test.ts
@@ -406,15 +406,15 @@ describe('eth_sendTransactionBatch handler', () => {
   });
 
   it('should add alert object with Warning type to displayData when validation result is Warning', async () => {
-    testWithValidationResultType('Warning');
+    await testWithValidationResultType('Warning');
   });
 
-  it('should add alert object with Warning type to displayData when validation result is Error', async () => {
-    testWithValidationResultType('Error');
+  it('should not add an alert to displayData when validation result is Error', async () => {
+    await testWithValidationResultType('Error');
   });
 
   it('should add alert object with Danger type to displayData when validation result is Malicious', async () => {
-    testWithValidationResultType('Malicious');
+    await testWithValidationResultType('Malicious');
   });
 
   it('should aggregate balance changes and token approvals in the upper-level displayData', async () => {
@@ -956,7 +956,7 @@ const testWithValidationResultType = async (resultType: 'Warning' | 'Error' | 'M
       })),
       updateTx,
     });
-  } else {
+  } else if (resultType === 'Warning') {
     const alert = {
       type: AlertType.WARNING,
       details: {
@@ -977,6 +977,24 @@ const testWithValidationResultType = async (resultType: 'Warning' | 'Error' | 'M
           ...req.displayData,
           isSimulationSuccessful: true,
           alert,
+        },
+      })),
+      updateTx,
+    });
+  } else {
+    // `result_type === 'Error'` is not a security verdict — no alert is raised.
+    expect(mockApprovalController.requestBatchApproval).toHaveBeenCalledWith({
+      request: requestParams.request,
+      displayData: {
+        ...displayData,
+        alert: undefined,
+      },
+      signingRequests: signingRequests.map((req) => ({
+        ...req,
+        displayData: {
+          ...req.displayData,
+          isSimulationSuccessful: true,
+          alert: undefined,
         },
       })),
       updateTx,

--- a/packages/evm-module/src/handlers/eth-send-transaction/eth-send-transaction.test.ts
+++ b/packages/evm-module/src/handlers/eth-send-transaction/eth-send-transaction.test.ts
@@ -359,15 +359,15 @@ describe('eth_sendTransaction handler', () => {
   });
 
   it('should add alert object with Warning type to displayData when validation result is Warning', async () => {
-    testWithValidationResultType('Warning');
+    await testWithValidationResultType('Warning');
   });
 
-  it('should add alert object with Warning type to displayData when validation result is Error', async () => {
-    testWithValidationResultType('Error');
+  it('should not add an alert to displayData when validation result is Error', async () => {
+    await testWithValidationResultType('Error');
   });
 
   it('should add alert object with Danger type to displayData when validation result is Malicious', async () => {
-    testWithValidationResultType('Malicious');
+    await testWithValidationResultType('Malicious');
   });
 
   it('should process transaction and add token approvals and balance changes to displayData', async () => {
@@ -717,7 +717,7 @@ const testWithValidationResultType = async (resultType: 'Warning' | 'Error' | 'M
       signingData,
       updateTx,
     });
-  } else {
+  } else if (resultType === 'Warning') {
     expect(mockApprovalController.requestApproval).toHaveBeenCalledWith({
       request: requestParams.request,
       displayData: {
@@ -730,6 +730,14 @@ const testWithValidationResultType = async (resultType: 'Warning' | 'Error' | 'M
           },
         },
       },
+      signingData,
+      updateTx,
+    });
+  } else {
+    // `result_type === 'Error'` is not a security verdict — no alert is raised.
+    expect(mockApprovalController.requestApproval).toHaveBeenCalledWith({
+      request: requestParams.request,
+      displayData: { ...displayData, alert: undefined },
       signingData,
       updateTx,
     });

--- a/packages/evm-module/src/handlers/eth-sign/eth-sign.test.ts
+++ b/packages/evm-module/src/handlers/eth-sign/eth-sign.test.ts
@@ -203,15 +203,15 @@ describe('ethSign', () => {
   });
 
   it('should add alert object with Warning type to displayData when validation result is Warning', async () => {
-    testWithValidationResultType('Warning');
+    await testWithValidationResultType('Warning');
   });
 
-  it('should add alert object with Warning type to displayData when validation result is Error', async () => {
-    testWithValidationResultType('Error');
+  it('should not add an alert to displayData when validation result is Error', async () => {
+    await testWithValidationResultType('Error');
   });
 
   it('should add alert object with Danger type to displayData when validation result is Malicious', async () => {
-    testWithValidationResultType('Malicious');
+    await testWithValidationResultType('Malicious');
   });
 
   it('should add alert object with Warning type to displayData when schema validation error occurs in jsonRpc scan', async () => {
@@ -286,6 +286,8 @@ describe('ethSign', () => {
 });
 
 const testWithValidationResultType = async (resultType: 'Warning' | 'Error' | 'Malicious') => {
+  // `result_type === 'Error'` (e.g. an unsupported EIP-712 type Blockaid can't
+  // parse) is not a security verdict and must not raise an alert.
   const mockBlockaid = {
     evm: {
       jsonRpc: {
@@ -330,7 +332,7 @@ const testWithValidationResultType = async (resultType: 'Warning' | 'Error' | 'M
         }),
       }),
     );
-  } else {
+  } else if (resultType === 'Warning') {
     expect(mockApprovalController.requestApproval).toHaveBeenCalledWith(
       expect.objectContaining({
         displayData: expect.objectContaining({
@@ -342,6 +344,12 @@ const testWithValidationResultType = async (resultType: 'Warning' | 'Error' | 'M
             },
           },
         }),
+      }),
+    );
+  } else {
+    expect(mockApprovalController.requestApproval).toHaveBeenCalledWith(
+      expect.objectContaining({
+        displayData: expect.objectContaining({ alert: undefined }),
       }),
     );
   }

--- a/packages/evm-module/src/utils/process-transaction-simulation.test.ts
+++ b/packages/evm-module/src/utils/process-transaction-simulation.test.ts
@@ -1,7 +1,11 @@
 import { type AssetDiffs, processBalanceChange, processTransactionSimulation } from './process-transaction-simulation';
-import { RpcMethod, type TokenApprovals } from '@avalabs/vm-module-types';
+import { AlertType, RpcMethod, type TokenApprovals } from '@avalabs/vm-module-types';
 import simulationResult from './__mocks__/simulation-result';
+import { transactionAlerts } from './transaction-alerts';
+import type { JsonRpcBatchInternal } from '@avalabs/core-wallets-sdk';
 import Blockaid from '@blockaid/client';
+
+const emptyProvider = {} as unknown as JsonRpcBatchInternal;
 
 jest.mock('@blockaid/client', () => {
   return jest.fn().mockImplementation(() => {
@@ -43,6 +47,70 @@ describe('processTransactionSimulation', () => {
     });
 
     expect(result).toEqual(expect.objectContaining({ alert: undefined, isSimulationSuccessful: false }));
+  });
+
+  it.each(['Error', 'Benign'] as const)(
+    'should not raise an alert when Blockaid validation result_type is %s',
+    async (resultType) => {
+      const clonedSimulation = structuredClone(simulationResult);
+      clonedSimulation.validation.result_type = resultType;
+
+      const result = await processTransactionSimulation({
+        rpcMethod: RpcMethod.ETH_SEND_TRANSACTION,
+        params: { from: '0xFromAddress', to: '0xToAddress', value: '0xValue' },
+        chainId: 43112,
+        provider: emptyProvider,
+        simulationResult: clonedSimulation as unknown as Blockaid.TransactionScanResponse,
+      });
+
+      expect(result.alert).toBeUndefined();
+    },
+  );
+
+  it('should not raise an alert when the validation section is missing', async () => {
+    const clonedSimulation = structuredClone(simulationResult);
+    // @ts-expect-error - intentionally removing validation to simulate an unscored response
+    delete clonedSimulation.validation;
+
+    const result = await processTransactionSimulation({
+      rpcMethod: RpcMethod.ETH_SEND_TRANSACTION,
+      params: { from: '0xFromAddress', to: '0xToAddress', value: '0xValue' },
+      chainId: 43112,
+      provider: emptyProvider,
+      simulationResult: clonedSimulation as unknown as Blockaid.TransactionScanResponse,
+    });
+
+    expect(result.alert).toBeUndefined();
+  });
+
+  it('should raise a WARNING alert when validation result_type is Warning', async () => {
+    const clonedSimulation = structuredClone(simulationResult);
+    clonedSimulation.validation.result_type = 'Warning';
+
+    const result = await processTransactionSimulation({
+      rpcMethod: RpcMethod.ETH_SEND_TRANSACTION,
+      params: { from: '0xFromAddress', to: '0xToAddress', value: '0xValue' },
+      chainId: 43112,
+      provider: emptyProvider,
+      simulationResult: clonedSimulation as unknown as Blockaid.TransactionScanResponse,
+    });
+
+    expect(result.alert).toEqual(transactionAlerts[AlertType.WARNING]);
+  });
+
+  it('should raise a DANGER alert when validation result_type is Malicious', async () => {
+    const clonedSimulation = structuredClone(simulationResult);
+    clonedSimulation.validation.result_type = 'Malicious';
+
+    const result = await processTransactionSimulation({
+      rpcMethod: RpcMethod.ETH_SEND_TRANSACTION,
+      params: { from: '0xFromAddress', to: '0xToAddress', value: '0xValue' },
+      chainId: 43112,
+      provider: emptyProvider,
+      simulationResult: clonedSimulation as unknown as Blockaid.TransactionScanResponse,
+    });
+
+    expect(result.alert).toEqual(transactionAlerts[AlertType.DANGER]);
   });
 
   it('should get the tokenApprovals from the traces of the simulation result', async () => {

--- a/packages/evm-module/src/utils/process-transaction-simulation.ts
+++ b/packages/evm-module/src/utils/process-transaction-simulation.ts
@@ -91,9 +91,11 @@ export const processTransactionSimulation = async ({
   if (simulationResult) {
     const { validation, simulation, gas_estimation: gasEstimation } = simulationResult;
 
-    if (!validation || validation.result_type === 'Error' || validation.result_type === 'Warning') {
+    // Only surface an alert when Blockaid returns a genuine verdict. A missing
+    // validation or `result_type === 'Error'` is not a security signal
+    if (validation?.result_type === 'Warning') {
       alert = transactionAlerts[AlertType.WARNING];
-    } else if (validation.result_type === 'Malicious') {
+    } else if (validation?.result_type === 'Malicious') {
       alert = transactionAlerts[AlertType.DANGER];
     }
 
@@ -360,9 +362,11 @@ export const processJsonRpcSimulation = async ({
       blockaid,
     });
 
-    if (!validation || validation.result_type === 'Error' || validation.result_type === 'Warning') {
+    // Only surface an alert when Blockaid returns a genuine verdict. A missing
+    // validation or `result_type === 'Error'` is not a security signal
+    if (validation?.result_type === 'Warning') {
       alert = transactionAlerts[AlertType.WARNING];
-    } else if (validation.result_type === 'Malicious') {
+    } else if (validation?.result_type === 'Malicious') {
       alert = transactionAlerts[AlertType.DANGER];
     }
 


### PR DESCRIPTION
- Only surface a Blockaid transaction warning when the scan returns a genuine Warning or Malicious verdict. A missing validation or a `result_type` of `Error` (e.g. an unsupported EIP-712 message types) is no longer treated as a security signal and will not raise a "Suspicious transaction" alert