### PR TITLE
fix: custom tokens balances for supported chains

### DIFF
--- a/.changeset/puny-onions-allow.md
+++ b/.changeset/puny-onions-allow.md
@@ -1,0 +1,6 @@
+---
+'@avalabs/evm-module': minor
+'@avalabs/vm-module-types': minor
+---
+
+Add optional `customTokensOnly` flag to `getBalances`. When set, the EVM module fetches balances only for the provided custom tokens, querying them directly via RPC so real on-chain balances are returned even when an indexed provider doesn't cover them.

--- a/packages/evm-module/src/handlers/get-balances/balance-service-interface.ts
+++ b/packages/evm-module/src/handlers/get-balances/balance-service-interface.ts
@@ -27,6 +27,7 @@ export interface BalanceServiceInterface {
     pageSize: number;
     pageToken?: string;
     customTokens: ERC20Token[];
+    customTokensOnly?: boolean;
   }): Promise<Record<string, TokenWithBalanceEVM | Error>>;
 
   listNftBalances(params: { chainId: number; address: string }): Promise<Record<string, NftTokenWithBalance | Error>>;

--- a/packages/evm-module/src/handlers/get-balances/get-balances.test.ts
+++ b/packages/evm-module/src/handlers/get-balances/get-balances.test.ts
@@ -285,4 +285,62 @@ describe('getBalances', () => {
       expect(glacierService.listNftBalances).not.toHaveBeenCalled();
     });
   });
+
+  describe('when customTokensOnly is true', () => {
+    let mockedRpcService: jest.Mocked<RpcService>;
+
+    beforeEach(() => {
+      mockedRpcService = new RpcService({
+        customTokens,
+        network,
+        proxyApiUrl,
+      }) as jest.Mocked<RpcService>;
+      const mockFindAsync = findAsync as jest.MockedFunction<typeof findAsync>;
+      mockFindAsync.mockResolvedValue(mockedRpcService);
+      mockedRpcService.isNetworkSupported.mockResolvedValue(true);
+      mockedRpcService.listErc20Balances.mockResolvedValue({
+        '0xtoken1': { symbol: 'TOKEN1', address: '0xToken1' } as TokenWithBalanceEVM,
+      });
+    });
+
+    it('only fetches ERC-20 balances for the custom tokens, skipping native and NFTs', async () => {
+      const result = await getBalances({
+        addresses: ['0xAddress1'],
+        currency,
+        network,
+        proxyApiUrl,
+        customTokens,
+        customTokensOnly: true,
+        balanceServices: [glacierService, deBankService],
+        tokenService: mockTokenService,
+      });
+
+      expect(mockedRpcService.getNativeBalance).not.toHaveBeenCalled();
+      expect(mockedRpcService.listNftBalances).not.toHaveBeenCalled();
+      expect(mockedRpcService.listErc20Balances).toHaveBeenCalledWith(
+        expect.objectContaining({ customTokensOnly: true }),
+      );
+      expect(result).toEqual({
+        '0xAddress1': { '0xtoken1': { symbol: 'TOKEN1', address: '0xToken1' } },
+      });
+    });
+
+    it('ignores tokenTypes and never uses indexed balance services', async () => {
+      await getBalances({
+        addresses: ['0xAddress1'],
+        currency,
+        network,
+        proxyApiUrl,
+        customTokens,
+        customTokensOnly: true,
+        tokenTypes: [TokenType.NATIVE, TokenType.ERC20, TokenType.ERC721],
+        balanceServices: [glacierService, deBankService],
+        tokenService: mockTokenService,
+      });
+
+      expect(glacierService.getNativeBalance).not.toHaveBeenCalled();
+      expect(glacierService.listErc20Balances).not.toHaveBeenCalled();
+      expect(deBankService.listErc20Balances).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/evm-module/src/handlers/get-balances/get-balances.ts
+++ b/packages/evm-module/src/handlers/get-balances/get-balances.ts
@@ -27,6 +27,7 @@ export const getBalances = async ({
   proxyApiUrl,
   tokenTypes = [TokenType.NATIVE, TokenType.ERC20, TokenType.ERC721, TokenType.ERC1155],
   customTokens = [],
+  customTokensOnly = false,
   storage,
   balanceServices = [],
   tokenService,
@@ -39,10 +40,13 @@ export const getBalances = async ({
   fetch?: typeof globalThis.fetch;
 }): Promise<GetEvmBalancesResponse> => {
   const chainId = network.chainId;
-  const services: BalanceServiceInterface[] = [
-    ...balanceServices,
-    new RpcService({ network, storage, proxyApiUrl, customTokens, fetch }),
-  ];
+  // When only custom tokens are requested we bypass indexed providers (which
+  // return a zero-balance polyfill for tokens they don't index) and query the
+  // chain directly via RPC to get the real on-chain balances.
+  const rpcService = new RpcService({ network, storage, proxyApiUrl, customTokens, fetch });
+  const services: BalanceServiceInterface[] = customTokensOnly ? [rpcService] : [...balanceServices, rpcService];
+
+  const resolvedTokenTypes = customTokensOnly ? [TokenType.ERC20] : tokenTypes;
 
   const supportingService: BalanceServiceInterface | undefined = await findAsync(
     services,
@@ -55,7 +59,7 @@ export const getBalances = async ({
     const erc20TokenPromises: Promise<IdPromise<Record<string, TokenWithBalanceEVM | Error>>>[] = [];
     const nftTokenPromises: Promise<IdPromise<Record<string, NftTokenWithBalance | Error>>>[] = [];
     addresses.forEach((address) => {
-      if (tokenTypes.includes(TokenType.NATIVE)) {
+      if (resolvedTokenTypes.includes(TokenType.NATIVE)) {
         nativeTokenPromises.push(
           addIdToPromise(
             supportingService
@@ -92,11 +96,12 @@ export const getBalances = async ({
         );
       }
 
-      if (tokenTypes.includes(TokenType.ERC20)) {
+      if (resolvedTokenTypes.includes(TokenType.ERC20)) {
         erc20TokenPromises.push(
           addIdToPromise(
             supportingService.listErc20Balances({
               customTokens: customTokens.filter(isERC20Token),
+              customTokensOnly,
               currency: currency.toUpperCase() as CurrencyCode,
               chainId,
               address,
@@ -107,7 +112,7 @@ export const getBalances = async ({
         );
       }
 
-      if (tokenTypes.includes(TokenType.ERC721) || tokenTypes.includes(TokenType.ERC1155)) {
+      if (resolvedTokenTypes.includes(TokenType.ERC721) || resolvedTokenTypes.includes(TokenType.ERC1155)) {
         nftTokenPromises.push(
           addIdToPromise(
             supportingService.listNftBalances({

--- a/packages/evm-module/src/module.ts
+++ b/packages/evm-module/src/module.ts
@@ -112,6 +112,7 @@ export class EvmModule implements Module {
     customTokens,
     storage,
     tokenTypes,
+    customTokensOnly,
   }: GetBalancesParams): Promise<GetBalancesResponse> {
     const tokenService = new TokenService({ storage, proxyApiUrl: this.#proxyApiUrl, fetch: this.#runtime?.fetch });
     return getBalances({
@@ -120,6 +121,7 @@ export class EvmModule implements Module {
       network,
       proxyApiUrl: this.#proxyApiUrl,
       customTokens,
+      customTokensOnly,
       balanceServices: [this.#glacierService, this.#deBankService],
       storage,
       tokenTypes,

--- a/packages/evm-module/src/services/rpc-service/rpc-service.test.ts
+++ b/packages/evm-module/src/services/rpc-service/rpc-service.test.ts
@@ -181,5 +181,59 @@ describe('RpcService', () => {
         reputation: null,
       });
     });
+
+    it('skips the curated token list and only queries custom tokens when customTokensOnly is true', async () => {
+      const mockAddress = '0xMockAddress';
+      const mockChainId = 1;
+      const mockCurrency = 'usd' as CurrencyCode;
+      const customToken: ERC20Token = {
+        name: 'CUSTOM',
+        type: TokenType.ERC20,
+        address: '0xCustomTokenAddress',
+        symbol: 'CUST',
+        decimals: 18,
+      };
+      const mockBalanceBigInt = 5000000000000000000n;
+
+      const rpcServiceWithCustom = new RpcService({
+        network: mockNetwork,
+        proxyApiUrl: mockProxyApiUrl,
+        customTokens: [customToken],
+      });
+
+      (getTokens as jest.Mock).mockClear();
+
+      const mockProvider = {
+        getBalance: jest.fn().mockResolvedValue(mockBalanceBigInt),
+      };
+      (getProvider as jest.Mock).mockReturnValue(mockProvider);
+
+      const mockContract = {
+        balanceOf: jest.fn().mockResolvedValue(mockBalanceBigInt),
+      };
+      (ethers.Contract as jest.Mock).mockReturnValue(mockContract);
+
+      const mockTokenService = {
+        getPricesByAddresses: jest.fn().mockResolvedValue({}),
+      };
+      (TokenService as jest.Mock).mockReturnValue(mockTokenService);
+
+      const result = await rpcServiceWithCustom.listErc20Balances({
+        chainId: mockChainId,
+        address: mockAddress,
+        currency: mockCurrency,
+        pageSize: 10,
+        customTokensOnly: true,
+      });
+
+      expect(getTokens).not.toHaveBeenCalled();
+      expect(result[customToken.address.toLowerCase()]).toEqual(
+        expect.objectContaining({
+          address: '0xCustomTokenAddress',
+          balance: mockBalanceBigInt,
+          type: TokenType.ERC20,
+        }),
+      );
+    });
   });
 });

--- a/packages/evm-module/src/services/rpc-service/rpc-service.ts
+++ b/packages/evm-module/src/services/rpc-service/rpc-service.ts
@@ -111,12 +111,14 @@ export class RpcService implements BalanceServiceInterface {
     chainId,
     address,
     currency,
+    customTokensOnly = false,
   }: {
     chainId: number;
     address: string;
     currency: CurrencyCode;
     pageSize: number;
     pageToken?: string;
+    customTokensOnly?: boolean;
   }): Promise<Record<TokenId, TokenWithBalanceEVM | Error>> {
     const provider = await getProvider({
       chainId,
@@ -128,7 +130,11 @@ export class RpcService implements BalanceServiceInterface {
 
     const coingeckoPlatformId = this.#network.pricingProviders?.coingecko.assetPlatformId;
     const coingeckoTokenId = this.#network.pricingProviders?.coingecko.nativeTokenId;
-    const tokens = await getTokens({ chainId: Number(chainId), proxyApiUrl: this.#proxyApiUrl });
+    // When only custom tokens are requested, skip fetching the full curated
+    // token list to keep the query cheap and targeted.
+    const tokens = customTokensOnly
+      ? []
+      : await getTokens({ chainId: Number(chainId), proxyApiUrl: this.#proxyApiUrl });
     const tokenAddresses = tokens.map((token) => token.address);
     const erc20TokenList = [...tokens, ...this.#customTokens].filter(isERC20Token);
 

--- a/packages/types/src/balance.ts
+++ b/packages/types/src/balance.ts
@@ -10,6 +10,12 @@ export type GetBalancesParams = {
   customTokens?: NetworkContractToken[];
   currency: string;
   storage?: Storage;
+  /**
+   * When true, only the balances for the provided `customTokens` are fetched,
+   * queried directly from the chain (RPC) rather than an indexed source. Used
+   * to back-fill custom tokens that an indexed balance provider doesn't cover.
+   */
+  customTokensOnly?: boolean;
 };
 
 export type TokenBalanceData = {


### PR DESCRIPTION
https://ava-labs.atlassian.net/browse/CP-14667

**Related Core Extension PR:** tbd

## Changes
* Updates `get-balances` handler arguments & `RpcService` for `EVMModule` such that it's now possible to only query balances for a given selection of token addresses. Useful for fetching balances of tokens that are not indexed by other balance providers (i.e. Core Balance API).