### PR TITLE
feat: Add new hypercore-module

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,7 +9,8 @@
       "@avalabs/vm-module-types",
       "@avalabs/bitcoin-module",
       "@avalabs/hvm-module",
-      "@avalabs/svm-module"
+      "@avalabs/svm-module",
+      "@avalabs/hypercore-module"
     ]
   ],
   "linked": [],

--- a/.changeset/hypercore-display-module.md
+++ b/.changeset/hypercore-display-module.md
@@ -1,0 +1,6 @@
+---
+'@avalabs/vm-module-types': minor
+'@avalabs/hypercore-module': minor
+---
+
+Add read-only HyperCore VM module (`hlcore:mainnet`) with `NetworkVMType.HYPERCORE`, `TokenType.HYPERCORE_SPOT`, and balance/history support.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ pnpm build    # builds all packages
 - `bitcoin-module`: Bitcoin module
 - `hvm-module`: Hyper VM Module
 - `svm-module`: Solana Virtual Machine module
+- `hypercore-module`: Hyperliquid HyperCore module
 - `types`: shared types for modules
 
 #### Internal

--- a/packages/hypercore-module/README.md
+++ b/packages/hypercore-module/README.md
@@ -1,0 +1,33 @@
+# HyperCore Module
+
+Read-only VM module for Hyperliquid **HyperCore** (spot balances, token registry, and activity).
+
+## Identity
+
+| Field             | Value                                                                         |
+| ----------------- | ----------------------------------------------------------------------------- |
+| Package           | `@avalabs/hypercore-module`                                                   |
+| CAIP-2            | `hlcore:mainnet`                                                              |
+| `NetworkVMType`   | `HYPERCORE`                                                                   |
+| Numeric `chainId` | `9999` (Core network-list id only; **not** an EVM chain id)                   |
+| Addresses         | EIP-55 EVM addresses (same as `addressC`); derivation is keyed as `HYPERCORE` |
+
+HyperEVM (`eip155:999`) is a normal EVM chain and stays on `@avalabs/evm-module`.
+
+## Capabilities
+
+**Implemented:** `getBalances`, `getTokens`, `getTransactionHistory`, `getManifest`, EVM-style `deriveAddress` / `deriveAddresses` / `buildDerivationPath` / `getAddress` (results keyed `HYPERCORE`).
+
+**Unsupported (loud reject / methodNotSupported):** `getProvider`, `getNetworkFee`, `onRpcRequest`. HyperCore has no RPC, gas model, or dApp methods in this module.
+
+## Balances
+
+- USDC is `TokenType.NATIVE` (unit of account at $1).
+- Other spot inventory is `TokenType.HYPERCORE_SPOT` (identity is spot `index`; optional `evmContract` when bridged to HyperEVM).
+- Perp **collateral** (ex-unrealized PnL) folds into USDC except for `unifiedAccount` mode. Open perp positions are not listed.
+
+## Installation
+
+```sh
+pnpm add @avalabs/hypercore-module
+```

--- a/packages/hypercore-module/jest.config.js
+++ b/packages/hypercore-module/jest.config.js
@@ -1,0 +1,10 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+export default {
+  clearMocks: true,
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  maxWorkers: 1,
+  transform: {
+    '.ts': ['ts-jest', { tsconfig: './tsconfig.jest.json' }],
+  },
+};

--- a/packages/hypercore-module/manifest.json
+++ b/packages/hypercore-module/manifest.json
@@ -1,0 +1,30 @@
+{
+  "name": "HyperCore",
+  "description": "Read-only Hyperliquid HyperCore module (balances, tokens, activity).",
+  "version": "0.0.1",
+  "sources": {
+    "module": {
+      "checksum": "",
+      "location": {
+        "npm": {
+          "filePath": "dist/index.js",
+          "packageName": "@avalabs/hypercore-module",
+          "registry": "https://registry.npmjs.org"
+        }
+      }
+    }
+  },
+  "network": {
+    "chainIds": ["hlcore:mainnet"],
+    "namespaces": ["hlcore"]
+  },
+  "cointype": "60",
+  "permissions": {
+    "rpc": {
+      "dapps": false,
+      "methods": [],
+      "nonRestrictedMethods": []
+    }
+  },
+  "manifestVersion": "0.1"
+}

--- a/packages/hypercore-module/package.json
+++ b/packages/hypercore-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avalabs/hypercore-module",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/ava-labs/core-vm-modules",

--- a/packages/hypercore-module/package.json
+++ b/packages/hypercore-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avalabs/hypercore-module",
-  "version": "3.9.3",
+  "version": "3.10.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/ava-labs/core-vm-modules",

--- a/packages/hypercore-module/package.json
+++ b/packages/hypercore-module/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@avalabs/hypercore-module",
+  "version": "3.9.3",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ava-labs/core-vm-modules",
+    "directory": "packages/hypercore-module"
+  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "typings": "dist/index.d.ts",
+  "type": "module",
+  "files": [
+    "dist",
+    "manifest.json"
+  ],
+  "license": "Limited Ecosystem License",
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "lint": "eslint \"src/**/*.ts\"",
+    "test": "jest",
+    "test:watch": "jest --watch"
+  },
+  "dependencies": {
+    "@avalabs/core-wallets-sdk": "3.1.0-alpha.87",
+    "@avalabs/crypto-sdk": "1.0.0",
+    "@avalabs/vm-module-types": "workspace:*",
+    "@metamask/rpc-errors": "6.3.0",
+    "big.js": "6.2.1",
+    "zod": "3.23.8"
+  },
+  "devDependencies": {
+    "@internal/tsup-config": "workspace:*",
+    "@internal/utils": "workspace:*",
+    "@types/big.js": "6.2.2",
+    "@types/jest": "29.5.7",
+    "eslint-config-custom": "workspace:*",
+    "ethers": "6.13.5",
+    "jest": "29.7.0",
+    "ts-jest": "29.1.1",
+    "tsup": "7.2.0"
+  },
+  "peerDependencies": {
+    "ethers": "6.13.5"
+  }
+}

--- a/packages/hypercore-module/src/constants.ts
+++ b/packages/hypercore-module/src/constants.ts
@@ -1,4 +1,6 @@
-/** CAIP-2 id for HyperCore mainnet. Namespace must be 3–8 chars (CAIP-2). */
+/** CAIP-2 id for HyperCore mainnet. Namespace must be 3–8 chars (CAIP-2).
+ * This is a synthetic CAIP-2 for the HyperCore network as HyperCore does not have a chain id.
+ */
 export const HYPERCORE_CAIP_ID = 'hlcore:mainnet';
 
 /**

--- a/packages/hypercore-module/src/constants.ts
+++ b/packages/hypercore-module/src/constants.ts
@@ -1,0 +1,12 @@
+/** CAIP-2 id for HyperCore mainnet. Namespace must be 3–8 chars (CAIP-2). */
+export const HYPERCORE_CAIP_ID = 'hlcore:mainnet';
+
+/**
+ * Synthetic numeric id used by Core network lists / storage keys.
+ * Not an EVM chain id — module routing uses {@link HYPERCORE_CAIP_ID}.
+ */
+export const HYPERCORE_CHAIN_ID = 9999;
+
+export const HYPERCORE_USDC_SYMBOL = 'USDC';
+export const HYPERCORE_USDC_NAME = 'USD Coin';
+export const HYPERCORE_USDC_DECIMALS = 8;

--- a/packages/hypercore-module/src/env.ts
+++ b/packages/hypercore-module/src/env.ts
@@ -1,0 +1,36 @@
+import { Environment } from '@avalabs/vm-module-types';
+
+type Env = {
+  proxyApiUrl: string;
+  /** Proxy-first Hyperliquid `/info` endpoint. */
+  infoUrl: string;
+  /**
+   * Fallback for activity endpoints if the proxy does not support fills/ledger.
+   * Prefer `infoUrl` when possible.
+   */
+  activityInfoUrl: string;
+};
+
+const INFO_PATH = '/proxy/nownodes/hype/info';
+const PUBLIC_ACTIVITY_INFO_URL = 'https://api.hyperliquid.xyz/info';
+
+export const prodEnv: Env = {
+  proxyApiUrl: 'https://proxy-api.avax.network',
+  infoUrl: `https://proxy-api.avax.network${INFO_PATH}`,
+  activityInfoUrl: PUBLIC_ACTIVITY_INFO_URL,
+};
+
+export const devEnv: Env = {
+  proxyApiUrl: 'https://proxy-api-dev.avax.network',
+  infoUrl: `https://proxy-api-dev.avax.network${INFO_PATH}`,
+  activityInfoUrl: PUBLIC_ACTIVITY_INFO_URL,
+};
+
+export const getEnv = (environment: Environment): Env => {
+  switch (environment) {
+    case Environment.PRODUCTION:
+      return prodEnv;
+    case Environment.DEV:
+      return devEnv;
+  }
+};

--- a/packages/hypercore-module/src/handlers/build-derivation-path/build-derivation-path.ts
+++ b/packages/hypercore-module/src/handlers/build-derivation-path/build-derivation-path.ts
@@ -1,0 +1,34 @@
+import { rpcErrors } from '@metamask/rpc-errors';
+import {
+  NetworkVMType,
+  type BuildDerivationPathParams,
+  type BuildDerivationPathResponse,
+} from '@avalabs/vm-module-types';
+
+/**
+ * HyperCore identity is an EVM address (cointype 60). Paths match the EVM module;
+ * the result is keyed as `HYPERCORE`.
+ */
+export const buildDerivationPath = ({
+  accountIndex,
+  derivationPathType,
+}: BuildDerivationPathParams): Pick<BuildDerivationPathResponse, NetworkVMType.HYPERCORE> => {
+  if (accountIndex < 0) {
+    throw rpcErrors.invalidParams('Account index must be a non-negative integer');
+  }
+
+  switch (derivationPathType) {
+    case 'bip44':
+      return {
+        [NetworkVMType.HYPERCORE]: `m/44'/60'/0'/0/${accountIndex}`,
+      };
+
+    case 'ledger_live':
+      return {
+        [NetworkVMType.HYPERCORE]: `m/44'/60'/${accountIndex}'/0/0`,
+      };
+
+    default:
+      throw rpcErrors.invalidParams(`Unsupported derivation path type: ${derivationPathType}`);
+  }
+};

--- a/packages/hypercore-module/src/handlers/derive-address/derive-address.ts
+++ b/packages/hypercore-module/src/handlers/derive-address/derive-address.ts
@@ -1,0 +1,34 @@
+import {
+  NetworkVMType,
+  type ApprovalController,
+  type DeriveAddressParams,
+  type DeriveAddressResponse,
+} from '@avalabs/vm-module-types';
+import { computeAddress } from 'ethers';
+import { hasDerivationDetails } from '@internal/utils/src/utils/address-derivation';
+import { buildDerivationPath } from '../build-derivation-path/build-derivation-path';
+
+export const deriveAddress = async (
+  params: DeriveAddressParams & { approvalController: ApprovalController },
+): Promise<DeriveAddressResponse> => {
+  const { secretId, approvalController } = params;
+
+  // Narrow before calling buildDerivationPath — the type guard alone is not
+  // enough when `params` is intersected with `{ approvalController }`.
+  const derivationPath = hasDerivationDetails(params)
+    ? buildDerivationPath({
+        accountIndex: params.accountIndex,
+        derivationPathType: params.derivationPathType,
+        addressIndex: params.addressIndex,
+      }).HYPERCORE
+    : undefined;
+  const publicKeyHex = await approvalController.requestPublicKey({
+    curve: 'secp256k1',
+    secretId,
+    derivationPath,
+  });
+
+  return {
+    [NetworkVMType.HYPERCORE]: computeAddress(`0x${publicKeyHex}`),
+  };
+};

--- a/packages/hypercore-module/src/handlers/derive-addresses/derive-addresses.ts
+++ b/packages/hypercore-module/src/handlers/derive-addresses/derive-addresses.ts
@@ -1,0 +1,36 @@
+import {
+  NetworkVMType,
+  type ApprovalController,
+  type DeriveAddressesParams,
+  type DeriveAddressesResponse,
+} from '@avalabs/vm-module-types';
+import { deriveAddressesForEvm, init } from '@avalabs/crypto-sdk';
+import { buildDerivationPath } from '../build-derivation-path/build-derivation-path';
+
+export const deriveAddresses = async (
+  params: DeriveAddressesParams & { approvalController: ApprovalController },
+): Promise<DeriveAddressesResponse> => {
+  const { approvalController, secretId, accountIndices, derivationPathType } = params;
+
+  if (accountIndices.length === 0) {
+    return [];
+  }
+
+  await init();
+
+  const publicKeys = await Promise.all(
+    accountIndices.map(async (accountIndex) => {
+      const derivationPath = buildDerivationPath({ accountIndex, derivationPathType }).HYPERCORE;
+      const publicKeyHex = await approvalController.requestPublicKey({
+        curve: 'secp256k1',
+        secretId,
+        derivationPath,
+      });
+      return Uint8Array.from(Buffer.from(publicKeyHex, 'hex'));
+    }),
+  );
+
+  const addresses = await deriveAddressesForEvm(publicKeys);
+
+  return addresses.map((address) => ({ [NetworkVMType.HYPERCORE]: address }));
+};

--- a/packages/hypercore-module/src/handlers/get-address/get-address.ts
+++ b/packages/hypercore-module/src/handlers/get-address/get-address.ts
@@ -1,0 +1,26 @@
+import { NetworkVMType, WalletType, type GetAddressParams, type GetAddressResponse } from '@avalabs/vm-module-types';
+import { getAddressFromXPub, getEvmAddressFromPubKey } from '@avalabs/core-wallets-sdk';
+import { rpcErrors } from '@metamask/rpc-errors';
+
+type GetAddress = Omit<GetAddressParams, 'isTestnet' | 'xpubXP' | 'network'>;
+
+export const getAddress = async ({ accountIndex, xpub, walletType }: GetAddress): Promise<GetAddressResponse> => {
+  switch (walletType) {
+    case WalletType.Mnemonic:
+    case WalletType.Ledger:
+    case WalletType.Keystone: {
+      return {
+        [NetworkVMType.HYPERCORE]: getAddressFromXPub(xpub, accountIndex),
+      };
+    }
+    case WalletType.LedgerLive:
+    case WalletType.Seedless: {
+      const pubKeyBuffer = Buffer.from(xpub, 'hex');
+      return {
+        [NetworkVMType.HYPERCORE]: getEvmAddressFromPubKey(pubKeyBuffer),
+      };
+    }
+    default:
+      throw rpcErrors.invalidParams(`Unsupported wallet type: ${walletType}`);
+  }
+};

--- a/packages/hypercore-module/src/handlers/get-balances/get-balances.ts
+++ b/packages/hypercore-module/src/handlers/get-balances/get-balances.ts
@@ -15,6 +15,8 @@ type GetHypercoreBalancesParams = Omit<GetBalancesParams, 'currency' | 'customTo
   infoClient: HypercoreInfoClient;
 };
 
+const toErrorMessage = (err: unknown) => (err instanceof Error ? err.message : String(err));
+
 const toTokenWithBalance = (
   token: HypercoreTokenBalance,
   networkToken: GetBalancesParams['network']['networkToken'],
@@ -68,43 +70,44 @@ export const getBalances = async ({
     return Object.fromEntries(addresses.map((address) => [address, {}]));
   }
 
-  const spotMeta = await infoClient.getSpotMeta();
-  const spotTokens = toHypercoreSpotTokens(spotMeta.tokens);
+  // Spot meta is only required to label non-USDC spot inventory. Native USDC is
+  // derived from spot clearinghouse balances (+ optional perp collateral).
+  const spotTokens = includeSpot ? toHypercoreSpotTokens((await infoClient.getSpotMeta()).tokens) : [];
 
   const results = await Promise.allSettled(
     addresses.map(async (address) => {
-      try {
-        const [spotState, perpState, abstractionMode] = await Promise.all([
-          infoClient.getSpotClearinghouseState(address),
-          includeNative ? infoClient.getClearinghouseState(address).catch(() => undefined) : Promise.resolve(undefined),
-          includeNative ? infoClient.getUserAbstraction(address).catch(() => undefined) : Promise.resolve(undefined),
-        ]);
+      const [spotState, perpState, abstractionMode] = await Promise.all([
+        infoClient.getSpotClearinghouseState(address),
+        includeNative ? infoClient.getClearinghouseState(address) : Promise.resolve(undefined),
+        includeNative ? infoClient.getUserAbstraction(address) : Promise.resolve(undefined),
+      ]);
 
-        const tokens = buildHypercoreTokens({
-          spotBalances: spotState.balances,
-          perpState,
-          abstractionMode,
-          spotTokens,
-        }).filter((token) => (token.kind === 'native' ? includeNative : includeSpot));
+      const tokens = buildHypercoreTokens({
+        spotBalances: spotState.balances,
+        perpState,
+        abstractionMode,
+        spotTokens,
+      }).filter((token) => (token.kind === 'native' ? includeNative : includeSpot));
 
-        const bySymbol = Object.fromEntries(
-          tokens.map((token) => {
-            const { key, value } = toTokenWithBalance(token, network.networkToken);
-            return [key, value];
-          }),
-        );
+      const bySymbol = Object.fromEntries(
+        tokens.map((token) => {
+          const { key, value } = toTokenWithBalance(token, network.networkToken);
+          return [key, value];
+        }),
+      );
 
-        return { [address]: bySymbol };
-      } catch (err) {
-        return { [address]: { error: (err as Error).toString() } };
-      }
+      return { [address]: bySymbol };
     }),
   );
 
-  return results.reduce((acc, curr) => {
+  return results.reduce((acc, curr, index) => {
     if (curr.status === 'fulfilled') {
       return { ...acc, ...curr.value };
     }
-    return acc;
+    const address = addresses[index];
+    if (!address) {
+      return acc;
+    }
+    return { ...acc, [address]: { error: toErrorMessage(curr.reason) } };
   }, {} as GetBalancesResponse);
 };

--- a/packages/hypercore-module/src/handlers/get-balances/get-balances.ts
+++ b/packages/hypercore-module/src/handlers/get-balances/get-balances.ts
@@ -1,0 +1,102 @@
+import {
+  TokenType,
+  type GetBalancesParams,
+  type GetBalancesResponse,
+  type NetworkTokenWithBalance,
+  type TokenWithBalance,
+  type TokenWithBalanceHypercoreSpot,
+} from '@avalabs/vm-module-types';
+import type { HypercoreInfoClient } from '../../utils/info-client';
+import { buildHypercoreTokens, type HypercoreTokenBalance } from '../../utils/build-hypercore-tokens';
+import { hyperliquidCoinSvgUrl } from '../../utils/hyperliquid-coin-svg-url';
+import { toHypercoreSpotTokens } from '../../utils/spot-tokens';
+
+type GetHypercoreBalancesParams = Omit<GetBalancesParams, 'currency' | 'customTokens' | 'tokenTypes'> & {
+  infoClient: HypercoreInfoClient;
+};
+
+const toTokenWithBalance = (
+  token: HypercoreTokenBalance,
+  networkToken: GetBalancesParams['network']['networkToken'],
+): { key: string; value: TokenWithBalance } => {
+  if (token.kind === 'native') {
+    const balance = BigInt(token.balanceRaw);
+    const balanceInCurrency = Number(token.balanceUsd);
+    const native: NetworkTokenWithBalance = {
+      ...networkToken,
+      name: token.name,
+      symbol: token.symbol,
+      decimals: token.decimals,
+      logoUri: networkToken.logoUri ?? hyperliquidCoinSvgUrl(token.symbol),
+      coingeckoId: 'usd-coin',
+      type: TokenType.NATIVE,
+      balance,
+      balanceDisplayValue: token.balance,
+      balanceInCurrency: Number.isFinite(balanceInCurrency) ? balanceInCurrency : 0,
+      balanceCurrencyDisplayValue: token.balanceUsd,
+      priceInCurrency: token.priceUsd,
+    };
+    return { key: token.symbol, value: native };
+  }
+
+  const balance = BigInt(token.balanceRaw);
+  const spot: TokenWithBalanceHypercoreSpot = {
+    type: TokenType.HYPERCORE_SPOT,
+    name: token.name,
+    symbol: token.symbol,
+    decimals: token.decimals,
+    index: token.index,
+    evmContract: token.evmContract,
+    logoUri: hyperliquidCoinSvgUrl(token.symbol),
+    reputation: null,
+    balance,
+    balanceDisplayValue: token.balance,
+  };
+  return { key: `spot:${token.index}`, value: spot };
+};
+
+export const getBalances = async ({
+  addresses,
+  network,
+  infoClient,
+}: GetHypercoreBalancesParams): Promise<GetBalancesResponse> => {
+  const spotMeta = await infoClient.getSpotMeta();
+  const spotTokens = toHypercoreSpotTokens(spotMeta.tokens);
+
+  const results = await Promise.allSettled(
+    addresses.map(async (address) => {
+      try {
+        const [spotState, perpState, abstractionMode] = await Promise.all([
+          infoClient.getSpotClearinghouseState(address),
+          infoClient.getClearinghouseState(address).catch(() => undefined),
+          infoClient.getUserAbstraction(address).catch(() => undefined),
+        ]);
+
+        const tokens = buildHypercoreTokens({
+          spotBalances: spotState.balances,
+          perpState,
+          abstractionMode,
+          spotTokens,
+        });
+
+        const bySymbol = Object.fromEntries(
+          tokens.map((token) => {
+            const { key, value } = toTokenWithBalance(token, network.networkToken);
+            return [key, value];
+          }),
+        );
+
+        return { [address]: bySymbol };
+      } catch (err) {
+        return { [address]: { error: (err as Error).toString() } };
+      }
+    }),
+  );
+
+  return results.reduce((acc, curr) => {
+    if (curr.status === 'fulfilled') {
+      return { ...acc, ...curr.value };
+    }
+    return acc;
+  }, {} as GetBalancesResponse);
+};

--- a/packages/hypercore-module/src/handlers/get-balances/get-balances.ts
+++ b/packages/hypercore-module/src/handlers/get-balances/get-balances.ts
@@ -11,7 +11,7 @@ import { buildHypercoreTokens, type HypercoreTokenBalance } from '../../utils/bu
 import { hyperliquidCoinSvgUrl } from '../../utils/hyperliquid-coin-svg-url';
 import { toHypercoreSpotTokens } from '../../utils/spot-tokens';
 
-type GetHypercoreBalancesParams = Omit<GetBalancesParams, 'currency' | 'customTokens' | 'tokenTypes'> & {
+type GetHypercoreBalancesParams = Omit<GetBalancesParams, 'currency' | 'customTokens'> & {
   infoClient: HypercoreInfoClient;
 };
 
@@ -59,7 +59,15 @@ export const getBalances = async ({
   addresses,
   network,
   infoClient,
+  tokenTypes = [TokenType.NATIVE, TokenType.HYPERCORE_SPOT],
 }: GetHypercoreBalancesParams): Promise<GetBalancesResponse> => {
+  const includeNative = tokenTypes.includes(TokenType.NATIVE);
+  const includeSpot = tokenTypes.includes(TokenType.HYPERCORE_SPOT);
+
+  if (!includeNative && !includeSpot) {
+    return Object.fromEntries(addresses.map((address) => [address, {}]));
+  }
+
   const spotMeta = await infoClient.getSpotMeta();
   const spotTokens = toHypercoreSpotTokens(spotMeta.tokens);
 
@@ -68,8 +76,8 @@ export const getBalances = async ({
       try {
         const [spotState, perpState, abstractionMode] = await Promise.all([
           infoClient.getSpotClearinghouseState(address),
-          infoClient.getClearinghouseState(address).catch(() => undefined),
-          infoClient.getUserAbstraction(address).catch(() => undefined),
+          includeNative ? infoClient.getClearinghouseState(address).catch(() => undefined) : Promise.resolve(undefined),
+          includeNative ? infoClient.getUserAbstraction(address).catch(() => undefined) : Promise.resolve(undefined),
         ]);
 
         const tokens = buildHypercoreTokens({
@@ -77,7 +85,7 @@ export const getBalances = async ({
           perpState,
           abstractionMode,
           spotTokens,
-        });
+        }).filter((token) => (token.kind === 'native' ? includeNative : includeSpot));
 
         const bySymbol = Object.fromEntries(
           tokens.map((token) => {

--- a/packages/hypercore-module/src/handlers/get-tokens/get-tokens.ts
+++ b/packages/hypercore-module/src/handlers/get-tokens/get-tokens.ts
@@ -1,0 +1,17 @@
+import type { HypercoreSpotToken, Network } from '@avalabs/vm-module-types';
+import type { HypercoreInfoClient } from '../../utils/info-client';
+import { hyperliquidCoinSvgUrl } from '../../utils/hyperliquid-coin-svg-url';
+import { toHypercoreSpotTokens } from '../../utils/spot-tokens';
+
+export const getTokens = async ({
+  infoClient,
+}: {
+  network: Network;
+  infoClient: HypercoreInfoClient;
+}): Promise<HypercoreSpotToken[]> => {
+  const spotMeta = await infoClient.getSpotMeta();
+  return toHypercoreSpotTokens(spotMeta.tokens).map((token) => ({
+    ...token,
+    logoUri: token.logoUri ?? hyperliquidCoinSvgUrl(token.symbol),
+  }));
+};

--- a/packages/hypercore-module/src/handlers/get-transaction-history/get-transaction-history.ts
+++ b/packages/hypercore-module/src/handlers/get-transaction-history/get-transaction-history.ts
@@ -1,0 +1,17 @@
+import type { GetTransactionHistory, TransactionHistoryResponse } from '@avalabs/vm-module-types';
+import type { HypercoreInfoClient } from '../../utils/info-client';
+import { fetchHypercoreActivity } from '../../utils/activity/fetch-hypercore-activity';
+import { mapHypercoreActivityToTransactions } from '../../utils/activity/map-hypercore-activity-to-transactions';
+
+export const getTransactionHistory = async ({
+  address,
+  network,
+  infoClient,
+}: GetTransactionHistory & {
+  infoClient: HypercoreInfoClient;
+}): Promise<TransactionHistoryResponse> => {
+  const items = await fetchHypercoreActivity(infoClient, address);
+  return {
+    transactions: mapHypercoreActivityToTransactions(items, address, network),
+  };
+};

--- a/packages/hypercore-module/src/index.ts
+++ b/packages/hypercore-module/src/index.ts
@@ -1,0 +1,14 @@
+export * from './module';
+export * from './constants';
+export * from './utils/schemas';
+export * from './utils/info-client';
+export * from './utils/spot-tokens';
+export * from './utils/build-hypercore-tokens';
+export * from './utils/hyperliquid-coin-svg-url';
+export * from './utils/activity/types';
+export * from './utils/activity/hypercore-fill-meta';
+export * from './utils/activity/get-hypercore-ledger-display';
+export * from './utils/activity/fetch-hypercore-activity';
+export * from './utils/activity/map-hypercore-activity-to-transactions';
+
+export type { HypercoreSpotToken } from '@avalabs/vm-module-types';

--- a/packages/hypercore-module/src/module.test.ts
+++ b/packages/hypercore-module/src/module.test.ts
@@ -1,0 +1,78 @@
+import {
+  AppName,
+  Environment,
+  NetworkVMType,
+  type ApprovalController,
+  type ConstructorParams,
+  type Network,
+} from '@avalabs/vm-module-types';
+import { HypercoreModule } from './module';
+
+// Short-circuit the @avalabs/crypto-wasm peer-resolution chain.
+jest.mock('@avalabs/crypto-sdk', () => ({}));
+import { HYPERCORE_CAIP_ID, HYPERCORE_CHAIN_ID } from './constants';
+
+const mockNetwork: Network = {
+  chainId: HYPERCORE_CHAIN_ID,
+  caipId: HYPERCORE_CAIP_ID,
+  chainName: 'HyperCore',
+  rpcUrl: '',
+  networkToken: {
+    name: 'USD Coin',
+    symbol: 'USDC',
+    decimals: 8,
+  },
+  vmName: NetworkVMType.HYPERCORE,
+  explorerUrl: 'https://app.hyperliquid.xyz/explorer',
+};
+
+const approvalController = {
+  requestPublicKey: jest.fn(),
+} as unknown as ApprovalController;
+
+const constructorParams: ConstructorParams = {
+  environment: Environment.DEV,
+  approvalController,
+  appInfo: { name: AppName.OTHER, version: '0.0.0' },
+};
+
+describe('HypercoreModule', () => {
+  const module = new HypercoreModule(constructorParams);
+
+  it('exposes a manifest for hlcore:mainnet', () => {
+    const manifest = module.getManifest();
+    expect(manifest?.network.chainIds).toContain(HYPERCORE_CAIP_ID);
+    expect(manifest?.network.namespaces).toContain('hlcore');
+    expect(manifest?.permissions.rpc.dapps).toBe(false);
+    expect(manifest?.permissions.rpc.methods).toEqual([]);
+  });
+
+  it('rejects getProvider', async () => {
+    await expect(module.getProvider(mockNetwork)).rejects.toThrow(/does not support getProvider/);
+  });
+
+  it('rejects getNetworkFee', async () => {
+    await expect(module.getNetworkFee(mockNetwork)).rejects.toThrow(/does not support getNetworkFee/);
+  });
+
+  it('returns methodNotSupported for onRpcRequest', async () => {
+    const result = await module.onRpcRequest(
+      {
+        method: 'eth_sendTransaction' as never,
+        params: [],
+        requestId: '1',
+        sessionId: '1',
+        chainId: HYPERCORE_CAIP_ID,
+        dappInfo: { name: 'test', url: 'https://example.com', icon: '' },
+      },
+      mockNetwork,
+    );
+    expect('error' in result && result.error).toBeTruthy();
+  });
+
+  it('builds EVM-style derivation paths keyed as HYPERCORE', () => {
+    expect(module.buildDerivationPath({ accountIndex: 0, derivationPathType: 'bip44' })).toEqual({
+      [NetworkVMType.HYPERCORE]: "m/44'/60'/0'/0/0",
+    });
+  });
+});

--- a/packages/hypercore-module/src/module.ts
+++ b/packages/hypercore-module/src/module.ts
@@ -1,0 +1,106 @@
+import type {
+  Module,
+  Manifest,
+  ConstructorParams,
+  ApprovalController,
+  RpcRequest,
+  Network,
+  NetworkFees,
+  GetBalancesParams,
+  GetAddressParams,
+  GetAddressResponse,
+  DeriveAddressParams,
+  DeriveAddressesParams,
+  BuildDerivationPathParams,
+  GetTransactionHistory,
+  NetworkFeeParam,
+} from '@avalabs/vm-module-types';
+import { parseManifest } from '@avalabs/vm-module-types';
+import { rpcErrors } from '@metamask/rpc-errors';
+
+import ManifestJson from '../manifest.json';
+import { getEnv } from './env';
+import { HypercoreInfoClient } from './utils/info-client';
+import { unsupportedHypercoreCapabilityMessage } from './utils/unsupported';
+import { getBalances } from './handlers/get-balances/get-balances';
+import { getTokens } from './handlers/get-tokens/get-tokens';
+import { getTransactionHistory } from './handlers/get-transaction-history/get-transaction-history';
+import { getAddress } from './handlers/get-address/get-address';
+import { deriveAddress } from './handlers/derive-address/derive-address';
+import { deriveAddresses } from './handlers/derive-addresses/derive-addresses';
+import { buildDerivationPath } from './handlers/build-derivation-path/build-derivation-path';
+
+export class HypercoreModule implements Module {
+  #approvalController: ApprovalController;
+  #infoClient: HypercoreInfoClient;
+
+  constructor({ environment, approvalController, runtime }: ConstructorParams) {
+    const { infoUrl, activityInfoUrl } = getEnv(environment);
+
+    this.#approvalController = approvalController;
+    this.#infoClient = new HypercoreInfoClient({
+      infoUrl,
+      activityInfoUrl,
+      fetch: runtime?.fetch,
+    });
+  }
+
+  getProvider(_network: Network): Promise<never> {
+    return Promise.reject(new Error(unsupportedHypercoreCapabilityMessage('getProvider')));
+  }
+
+  getManifest(): Manifest | undefined {
+    const result = parseManifest(ManifestJson);
+    return result.success ? result.data : undefined;
+  }
+
+  getBalances(params: GetBalancesParams) {
+    return getBalances({
+      ...params,
+      infoClient: this.#infoClient,
+    });
+  }
+
+  getTransactionHistory(params: GetTransactionHistory) {
+    return getTransactionHistory({
+      ...params,
+      infoClient: this.#infoClient,
+    });
+  }
+
+  getNetworkFee(_network: NetworkFeeParam): Promise<NetworkFees> {
+    return Promise.reject(new Error(unsupportedHypercoreCapabilityMessage('getNetworkFee')));
+  }
+
+  getAddress(params: GetAddressParams): Promise<GetAddressResponse> {
+    return getAddress(params);
+  }
+
+  buildDerivationPath(params: BuildDerivationPathParams) {
+    return buildDerivationPath(params);
+  }
+
+  deriveAddress(params: DeriveAddressParams) {
+    return deriveAddress({
+      ...params,
+      approvalController: this.#approvalController,
+    });
+  }
+
+  deriveAddresses(params: DeriveAddressesParams) {
+    return deriveAddresses({
+      ...params,
+      approvalController: this.#approvalController,
+    });
+  }
+
+  getTokens(network: Network) {
+    return getTokens({ network, infoClient: this.#infoClient });
+  }
+
+  async onRpcRequest(request: RpcRequest, _network: Network) {
+    return {
+      error: rpcErrors.methodNotSupported(`HyperCore is read-only; method ${request.method} is not supported`),
+    };
+  }
+}

--- a/packages/hypercore-module/src/utils/activity/fetch-hypercore-activity.ts
+++ b/packages/hypercore-module/src/utils/activity/fetch-hypercore-activity.ts
@@ -3,11 +3,15 @@ import type { HypercoreLedgerUpdate } from '../schemas';
 import type { HypercoreActivityItem } from './types';
 import { toTimeMs } from './types';
 
-/** Bound ledger pagination so busy accounts cannot trigger unbounded requests. */
+/**
+ * Safety cap only — ledger events are infrequent vs fills, so we normally stop
+ * on an empty page well before this. Hitting the cap would truncate the *newest*
+ * updates (pages are ascending from `startTime`).
+ */
 export const MAX_LEDGER_PAGES = 20;
 
-/** Prefer recent ledger history; paging from `0` would return the oldest pages first. */
-export const LEDGER_LOOKBACK_MS = 365 * 24 * 60 * 60 * 1000;
+/** Default ledger window; keep short so a capped crawl still covers recent activity. */
+export const LEDGER_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000;
 
 type FetchHypercoreActivityOptions = {
   signal?: AbortSignal;
@@ -29,9 +33,10 @@ const softFail = async <T>(promise: Promise<T>, fallback: T): Promise<T> => {
 
 /**
  * `userNonFundingLedgerUpdates` returns an ascending, capped page (~500) from
- * `startTime`. Start within a lookback window and page forward until empty,
- * aborted, or `MAX_LEDGER_PAGES`, so recent activity is included without an
- * unbounded crawl from epoch.
+ * `startTime`. A single request therefore returns the *oldest* rows in the
+ * window and can omit recent activity. Page forward — advancing past the last
+ * row's time — until empty (or the safety page cap), so the newest updates in
+ * the lookback window are included.
  */
 const fetchLedgerUpdates = async (
   client: HypercoreInfoClient,

--- a/packages/hypercore-module/src/utils/activity/fetch-hypercore-activity.ts
+++ b/packages/hypercore-module/src/utils/activity/fetch-hypercore-activity.ts
@@ -1,0 +1,101 @@
+import type { HypercoreInfoClient } from '../info-client';
+import type { HypercoreLedgerUpdate } from '../schemas';
+import type { HypercoreActivityItem } from './types';
+import { toTimeMs } from './types';
+
+/** Bound ledger pagination so busy accounts cannot trigger unbounded requests. */
+export const MAX_LEDGER_PAGES = 20;
+
+/** Prefer recent ledger history; paging from `0` would return the oldest pages first. */
+export const LEDGER_LOOKBACK_MS = 365 * 24 * 60 * 60 * 1000;
+
+type FetchHypercoreActivityOptions = {
+  signal?: AbortSignal;
+};
+
+const isAbortError = (err: unknown) =>
+  (err instanceof DOMException && err.name === 'AbortError') || (err instanceof Error && err.name === 'AbortError');
+
+const softFail = async <T>(promise: Promise<T>, fallback: T): Promise<T> => {
+  try {
+    return await promise;
+  } catch (err) {
+    if (isAbortError(err)) {
+      throw err;
+    }
+    return fallback;
+  }
+};
+
+/**
+ * `userNonFundingLedgerUpdates` returns an ascending, capped page (~500) from
+ * `startTime`. Start within a lookback window and page forward until empty,
+ * aborted, or `MAX_LEDGER_PAGES`, so recent activity is included without an
+ * unbounded crawl from epoch.
+ */
+const fetchLedgerUpdates = async (
+  client: HypercoreInfoClient,
+  evmAddress: string,
+  options?: FetchHypercoreActivityOptions,
+) => {
+  const all: HypercoreLedgerUpdate[] = [];
+  let startTime = Date.now() - LEDGER_LOOKBACK_MS;
+  let pages = 0;
+
+  while (pages < MAX_LEDGER_PAGES) {
+    if (options?.signal?.aborted) {
+      throw new DOMException('The operation was aborted.', 'AbortError');
+    }
+
+    const page = await client.getUserNonFundingLedgerUpdates(evmAddress, startTime, options);
+    pages += 1;
+    if (page.length === 0) {
+      break;
+    }
+    all.push(...page);
+    const last = page[page.length - 1];
+    if (!last) {
+      break;
+    }
+    const next = last.time + 1;
+    if (next <= startTime) {
+      break;
+    }
+    startTime = next;
+  }
+
+  return all;
+};
+
+/**
+ * Fetches HyperCore fills + non-funding ledger updates and sorts newest-first.
+ * Soft-fails individual endpoints so a flaky fills or ledger call still yields
+ * partial history (abort errors are rethrown).
+ */
+export const fetchHypercoreActivity = async (
+  client: HypercoreInfoClient,
+  evmAddress: string,
+  options?: FetchHypercoreActivityOptions,
+): Promise<HypercoreActivityItem[]> => {
+  const [fills, ledgerUpdates] = await Promise.all([
+    softFail(client.getUserFills(evmAddress, options), []),
+    softFail(fetchLedgerUpdates(client, evmAddress, options), []),
+  ]);
+
+  const items: HypercoreActivityItem[] = [
+    ...fills.map((fill) => ({
+      kind: 'fill' as const,
+      timeMs: toTimeMs(fill.time),
+      hash: fill.hash,
+      fill,
+    })),
+    ...ledgerUpdates.map((update) => ({
+      kind: 'ledger' as const,
+      timeMs: toTimeMs(update.time),
+      hash: update.hash,
+      update,
+    })),
+  ];
+
+  return items.sort((a, b) => b.timeMs - a.timeMs);
+};

--- a/packages/hypercore-module/src/utils/activity/get-hypercore-ledger-display.ts
+++ b/packages/hypercore-module/src/utils/activity/get-hypercore-ledger-display.ts
@@ -1,0 +1,133 @@
+import type { HypercoreLedgerUpdate } from '../schemas';
+
+/**
+ * Semantic label key for a ledger row.
+ */
+export type HypercoreLedgerLabel =
+  | 'deposit'
+  | 'withdraw'
+  | 'sent'
+  | 'received'
+  | 'transferToPerp'
+  | 'transferToSpot'
+  | 'transfer'
+  | 'liquidation'
+  | 'other';
+
+export type HypercoreLedgerDisplay = {
+  readonly label: HypercoreLedgerLabel;
+  /** Unsigned token amount, e.g. `0.1`. */
+  readonly amount: string;
+  readonly symbol: string;
+  /** Signed USD value for the fiat line; undefined when there's nothing to show. */
+  readonly usdValue?: number;
+  readonly direction: 'positive' | 'negative' | 'neutral';
+  readonly from?: string;
+  readonly to?: string;
+  readonly rawType: string;
+};
+
+const formatAmount = (value: string | undefined) => {
+  if (value === undefined || value === '') {
+    return '';
+  }
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed)) {
+    return value;
+  }
+  return new Intl.NumberFormat('en-US', { maximumFractionDigits: 6 }).format(parsed);
+};
+
+const toUsd = (value: string | undefined, sign: 1 | -1 | 0) => {
+  if (value === undefined || value === '') {
+    return undefined;
+  }
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed * (sign === 0 ? 1 : sign) : undefined;
+};
+
+/**
+ * Derives label, amount, signed USD value, and counterparties for a HyperCore
+ * ledger update from the owner's perspective.
+ */
+export const getHypercoreLedgerDisplay = (
+  update: HypercoreLedgerUpdate,
+  evmAddress: string,
+): HypercoreLedgerDisplay => {
+  const { delta } = update;
+  const owner = evmAddress.toLowerCase();
+  const isOutgoing = delta.user?.toLowerCase() === owner;
+
+  switch (delta.type) {
+    case 'deposit':
+      return {
+        label: 'deposit',
+        amount: formatAmount(delta.usdc),
+        symbol: 'USDC',
+        usdValue: toUsd(delta.usdc, 1),
+        direction: 'positive',
+        to: evmAddress,
+        rawType: delta.type,
+      };
+    case 'withdraw':
+      return {
+        label: 'withdraw',
+        amount: formatAmount(delta.usdc),
+        symbol: 'USDC',
+        usdValue: toUsd(delta.usdc, -1),
+        direction: 'negative',
+        from: evmAddress,
+        rawType: delta.type,
+      };
+    case 'send':
+    case 'spotTransfer':
+      return {
+        label: isOutgoing ? 'sent' : 'received',
+        amount: formatAmount(delta.amount),
+        symbol: delta.token ?? 'USDC',
+        usdValue: toUsd(delta.usdcValue, isOutgoing ? -1 : 1),
+        direction: isOutgoing ? 'negative' : 'positive',
+        from: delta.user,
+        to: delta.destination,
+        rawType: delta.type,
+      };
+    case 'internalTransfer':
+      return {
+        label: 'transfer',
+        amount: formatAmount(delta.usdc),
+        symbol: 'USDC',
+        usdValue: toUsd(delta.usdc, isOutgoing ? -1 : 1),
+        direction: isOutgoing ? 'negative' : 'positive',
+        from: delta.user,
+        to: delta.destination,
+        rawType: delta.type,
+      };
+    case 'accountClassTransfer':
+      return {
+        label: delta.toPerp ? 'transferToPerp' : 'transferToSpot',
+        amount: formatAmount(delta.usdc),
+        symbol: 'USDC',
+        usdValue: toUsd(delta.usdc, 0),
+        direction: 'neutral',
+        rawType: delta.type,
+      };
+    case 'liquidation':
+      return {
+        label: 'liquidation',
+        amount: formatAmount(delta.usdcValue ?? delta.usdc),
+        symbol: 'USDC',
+        usdValue: toUsd(delta.usdcValue ?? delta.usdc, -1),
+        direction: 'negative',
+        rawType: delta.type,
+      };
+    default:
+      return {
+        label: 'other',
+        amount: formatAmount(delta.usdcValue ?? delta.usdc),
+        symbol: 'USDC',
+        usdValue: toUsd(delta.usdcValue ?? delta.usdc, 0),
+        direction: 'neutral',
+        rawType: delta.type,
+      };
+  }
+};

--- a/packages/hypercore-module/src/utils/activity/hypercore-fill-meta.test.ts
+++ b/packages/hypercore-module/src/utils/activity/hypercore-fill-meta.test.ts
@@ -3,6 +3,7 @@ import {
   parseHypercoreFillMethod,
   tickerOfCoin,
   closedPnlTone,
+  fillLabel,
 } from './hypercore-fill-meta';
 
 describe('hypercoreFillMeta', () => {
@@ -15,6 +16,12 @@ describe('hypercoreFillMeta', () => {
     expect(closedPnlTone('1.5')).toBe('profit');
     expect(closedPnlTone('-2')).toBe('loss');
     expect(closedPnlTone('0')).toBeUndefined();
+  });
+
+  it('maps fill dirs to label direction', () => {
+    expect(fillLabel('Close Long', '1')).toEqual({ text: 'Long closed', direction: 'up', tone: 'profit' });
+    expect(fillLabel('Close Short', '-1')).toEqual({ text: 'Short closed', direction: 'down', tone: 'loss' });
+    expect(fillLabel('Open Long')).toEqual({ text: 'Order opened' });
   });
 
   it('round-trips fill method encoding', () => {

--- a/packages/hypercore-module/src/utils/activity/hypercore-fill-meta.test.ts
+++ b/packages/hypercore-module/src/utils/activity/hypercore-fill-meta.test.ts
@@ -1,0 +1,27 @@
+import {
+  encodeHypercoreFillMethod,
+  parseHypercoreFillMethod,
+  tickerOfCoin,
+  closedPnlTone,
+} from './hypercore-fill-meta';
+
+describe('hypercoreFillMeta', () => {
+  it('strips HIP-3 dex prefixes from coin tickers', () => {
+    expect(tickerOfCoin('xyz:GOLD')).toBe('GOLD');
+    expect(tickerOfCoin('ETH')).toBe('ETH');
+  });
+
+  it('derives PnL tone from closedPnl', () => {
+    expect(closedPnlTone('1.5')).toBe('profit');
+    expect(closedPnlTone('-2')).toBe('loss');
+    expect(closedPnlTone('0')).toBeUndefined();
+  });
+
+  it('round-trips fill method encoding', () => {
+    const meta = { dir: 'Open Long', px: '100', closedPnl: '0', coin: 'ETH' };
+    const encoded = encodeHypercoreFillMethod(meta);
+    expect(encoded.startsWith('hypercoreFill:v1:')).toBe(true);
+    expect(parseHypercoreFillMethod(encoded)).toEqual(meta);
+    expect(parseHypercoreFillMethod('other')).toBeUndefined();
+  });
+});

--- a/packages/hypercore-module/src/utils/activity/hypercore-fill-meta.ts
+++ b/packages/hypercore-module/src/utils/activity/hypercore-fill-meta.ts
@@ -1,0 +1,100 @@
+const METHOD_PREFIX = 'hypercoreFill:v1:';
+
+export const FILL_ARROW_UP = '\u25B2';
+export const FILL_ARROW_DOWN = '\u25BC';
+
+export type HypercoreFillMeta = {
+  readonly dir: string;
+  readonly px: string;
+  readonly closedPnl: string;
+  readonly coin: string;
+};
+
+export type FillLabel = {
+  readonly text: string;
+  readonly arrow?: typeof FILL_ARROW_UP | typeof FILL_ARROW_DOWN;
+  readonly tone?: 'profit' | 'loss';
+};
+
+/** Display ticker with any `dex:` prefix stripped (`xyz:GOLD` → `GOLD`). */
+export const tickerOfCoin = (coin: string) => {
+  const i = coin.indexOf(':');
+  return i === -1 ? coin : coin.slice(i + 1);
+};
+
+/** PnL tone from `closedPnl` — `dir` alone does not indicate profit vs loss. */
+export const closedPnlTone = (closedPnl: string | undefined): 'profit' | 'loss' | undefined => {
+  if (closedPnl === undefined) {
+    return undefined;
+  }
+  const n = Number.parseFloat(closedPnl);
+  if (!Number.isFinite(n) || n === 0) {
+    return undefined;
+  }
+  return n > 0 ? 'profit' : 'loss';
+};
+
+/**
+ * Map a fill's `dir` into a display label. Arrow direction follows side
+ * (long ▲ / short ▼); success/error tone comes from `closedPnl` when provided.
+ */
+export const fillLabel = (dir: string, closedPnl?: string): FillLabel => {
+  const tone = closedPnlTone(closedPnl);
+  const d = dir.toLowerCase();
+  if (d.includes('close') && d.includes('long')) {
+    return { text: 'Long closed', arrow: FILL_ARROW_UP, tone };
+  }
+  if (d.includes('close') && d.includes('short')) {
+    return { text: 'Short closed', arrow: FILL_ARROW_DOWN, tone };
+  }
+  if (d.includes('open') && (d.includes('long') || d.includes('short'))) {
+    return { text: 'Order opened' };
+  }
+  if (d.includes('cancel')) {
+    return { text: 'Order cancelled' };
+  }
+  return { text: dir };
+};
+
+/** Compact USD price for fill rows (`$1,684.7`). */
+export const formatHypercoreFillPx = (px: string) => {
+  const n = Number.parseFloat(px);
+  if (!Number.isFinite(n)) {
+    return px;
+  }
+  return `$${n.toLocaleString(undefined, { maximumFractionDigits: 8 })}`;
+};
+
+export const encodeHypercoreFillMethod = (meta: HypercoreFillMeta) =>
+  `${METHOD_PREFIX}${encodeURIComponent(JSON.stringify(meta))}`;
+
+export const parseHypercoreFillMethod = (method: string | undefined): HypercoreFillMeta | undefined => {
+  if (!method?.startsWith(METHOD_PREFIX)) {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(decodeURIComponent(method.slice(METHOD_PREFIX.length)));
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      !('dir' in parsed) ||
+      !('px' in parsed) ||
+      !('closedPnl' in parsed) ||
+      !('coin' in parsed)
+    ) {
+      return undefined;
+    }
+    const { dir, px, closedPnl, coin } = parsed as Record<string, unknown>;
+    if (
+      typeof dir !== 'string' ||
+      typeof px !== 'string' ||
+      typeof closedPnl !== 'string' ||
+      typeof coin !== 'string'
+    ) {
+      return undefined;
+    }
+    return { dir, px, closedPnl, coin };
+  } catch {
+    return undefined;
+  }
+};

--- a/packages/hypercore-module/src/utils/activity/hypercore-fill-meta.ts
+++ b/packages/hypercore-module/src/utils/activity/hypercore-fill-meta.ts
@@ -1,18 +1,20 @@
 const METHOD_PREFIX = 'hypercoreFill:v1:';
 
-export const FILL_ARROW_UP = '\u25B2';
-export const FILL_ARROW_DOWN = '\u25BC';
-
 export type HypercoreFillMeta = {
+  /** Fill side / action from Hyperliquid (`Open Long`, `Close Short`, …). */
   readonly dir: string;
+  /** Fill price as a decimal string (Hyperliquid `px`). */
   readonly px: string;
+  /** Realized PnL for the fill as a decimal string; `"0"` when none. */
   readonly closedPnl: string;
+  /** Market coin id (`ETH`, or HIP-3 `dex:TICKER`). */
   readonly coin: string;
 };
 
 export type FillLabel = {
   readonly text: string;
-  readonly arrow?: typeof FILL_ARROW_UP | typeof FILL_ARROW_DOWN;
+  /** Long / short cue for the UI to pick an icon. */
+  readonly direction?: 'up' | 'down';
   readonly tone?: 'profit' | 'loss';
 };
 
@@ -35,17 +37,17 @@ export const closedPnlTone = (closedPnl: string | undefined): 'profit' | 'loss' 
 };
 
 /**
- * Map a fill's `dir` into a display label. Arrow direction follows side
- * (long ▲ / short ▼); success/error tone comes from `closedPnl` when provided.
+ * Map a fill's `dir` into a display label. Direction follows side
+ * (long → up / short → down); success/error tone comes from `closedPnl` when provided.
  */
 export const fillLabel = (dir: string, closedPnl?: string): FillLabel => {
   const tone = closedPnlTone(closedPnl);
   const d = dir.toLowerCase();
   if (d.includes('close') && d.includes('long')) {
-    return { text: 'Long closed', arrow: FILL_ARROW_UP, tone };
+    return { text: 'Long closed', direction: 'up', tone };
   }
   if (d.includes('close') && d.includes('short')) {
-    return { text: 'Short closed', arrow: FILL_ARROW_DOWN, tone };
+    return { text: 'Short closed', direction: 'down', tone };
   }
   if (d.includes('open') && (d.includes('long') || d.includes('short'))) {
     return { text: 'Order opened' };

--- a/packages/hypercore-module/src/utils/activity/map-hypercore-activity-to-transactions.ts
+++ b/packages/hypercore-module/src/utils/activity/map-hypercore-activity-to-transactions.ts
@@ -1,0 +1,117 @@
+import { TokenType, TransactionType, type Network, type Transaction, type TxToken } from '@avalabs/vm-module-types';
+import { HYPERCORE_CAIP_ID } from '../../constants';
+import { hyperliquidCoinSvgUrl } from '../hyperliquid-coin-svg-url';
+import type { HypercoreLedgerUpdate, UserFill } from '../schemas';
+import { getHypercoreLedgerDisplay } from './get-hypercore-ledger-display';
+import { encodeHypercoreFillMethod, tickerOfCoin } from './hypercore-fill-meta';
+import type { HypercoreActivityItem } from './types';
+import { toTimeMs } from './types';
+
+const explorerTxLink = (network: Pick<Network, 'explorerUrl'>, hash: string) => {
+  const base = (network.explorerUrl ?? '').replace(/\/$/, '');
+  return base ? `${base}/tx/${hash}` : hash;
+};
+
+const chainIdForNetwork = (network: Pick<Network, 'caipId' | 'chainId'>) => network.caipId ?? HYPERCORE_CAIP_ID;
+
+const mapFillToTransaction = (
+  fill: UserFill,
+  timeMs: number,
+  network: Pick<Network, 'explorerUrl' | 'caipId' | 'chainId'>,
+): Transaction => {
+  const isBuy = fill.side === 'B';
+  const ticker = tickerOfCoin(fill.coin);
+
+  const token: TxToken = {
+    type: TokenType.NATIVE,
+    name: fill.coin,
+    symbol: ticker,
+    amount: fill.sz,
+    imageUri: hyperliquidCoinSvgUrl(fill.coin),
+  };
+
+  return {
+    isContractCall: false,
+    isIncoming: isBuy,
+    isOutgoing: !isBuy,
+    isSender: !isBuy,
+    timestamp: timeMs,
+    hash: fill.hash,
+    from: '',
+    to: '',
+    tokens: [token],
+    gasUsed: '0',
+    txType: TransactionType.FILL_ORDER,
+    method: encodeHypercoreFillMethod({
+      dir: fill.dir ?? '',
+      px: fill.px,
+      closedPnl: fill.closedPnl,
+      coin: fill.coin,
+    }),
+    chainId: chainIdForNetwork(network),
+    explorerLink: explorerTxLink(network, fill.hash),
+  };
+};
+
+const mapLedgerToTransaction = (
+  update: HypercoreLedgerUpdate,
+  evmAddress: string,
+  network: Pick<Network, 'explorerUrl' | 'caipId' | 'chainId'>,
+): Transaction => {
+  const display = getHypercoreLedgerDisplay(update, evmAddress);
+  const isIncoming = display.direction === 'positive';
+  const isOutgoing = display.direction === 'negative';
+
+  let txType: TransactionType = TransactionType.TRANSFER;
+  switch (display.label) {
+    case 'deposit':
+    case 'received':
+      txType = TransactionType.RECEIVE;
+      break;
+    case 'withdraw':
+    case 'sent':
+      txType = TransactionType.SEND;
+      break;
+    case 'liquidation':
+      txType = TransactionType.UNKNOWN;
+      break;
+    default:
+      txType = TransactionType.TRANSFER;
+  }
+
+  const amount = display.amount || '0';
+  const token: TxToken = {
+    type: TokenType.NATIVE,
+    name: display.symbol,
+    symbol: display.symbol,
+    amount,
+    imageUri: hyperliquidCoinSvgUrl(display.symbol),
+  };
+
+  return {
+    isContractCall: false,
+    isIncoming,
+    isOutgoing,
+    isSender: isOutgoing,
+    timestamp: toTimeMs(update.time),
+    hash: update.hash,
+    from: display.from ?? (isOutgoing ? evmAddress : ''),
+    to: display.to ?? (isIncoming ? evmAddress : ''),
+    tokens: [token],
+    gasUsed: '0',
+    txType,
+    chainId: chainIdForNetwork(network),
+    explorerLink: explorerTxLink(network, update.hash),
+  };
+};
+
+export const mapHypercoreActivityToTransactions = (
+  items: readonly HypercoreActivityItem[],
+  evmAddress: string,
+  network: Pick<Network, 'explorerUrl' | 'caipId' | 'chainId'>,
+): Transaction[] =>
+  items.map((item) =>
+    item.kind === 'fill'
+      ? mapFillToTransaction(item.fill, item.timeMs, network)
+      : mapLedgerToTransaction(item.update, evmAddress, network),
+  );

--- a/packages/hypercore-module/src/utils/activity/types.ts
+++ b/packages/hypercore-module/src/utils/activity/types.ts
@@ -1,0 +1,18 @@
+import type { HypercoreLedgerUpdate, UserFill } from '../schemas';
+
+export type HypercoreActivityItem =
+  | {
+      readonly kind: 'fill';
+      readonly timeMs: number;
+      readonly hash: string;
+      readonly fill: UserFill;
+    }
+  | {
+      readonly kind: 'ledger';
+      readonly timeMs: number;
+      readonly hash: string;
+      readonly update: HypercoreLedgerUpdate;
+    };
+
+/** Normalize a Unix timestamp to milliseconds. */
+export const toTimeMs = (time: number) => (time < 10_000_000_000 ? time * 1000 : time);

--- a/packages/hypercore-module/src/utils/build-hypercore-tokens.test.ts
+++ b/packages/hypercore-module/src/utils/build-hypercore-tokens.test.ts
@@ -1,0 +1,197 @@
+import type { ClearinghouseState, SpotBalance } from './schemas';
+import { buildHypercoreTokens, getPerpCollateralUsd, spotCountsAsPerpCollateral } from './build-hypercore-tokens';
+import { toHypercoreSpotTokens } from './spot-tokens';
+import { TokenType, type HypercoreSpotToken } from '@avalabs/vm-module-types';
+
+const spotBalance = (coin: string, token: number, total: string): SpotBalance => ({
+  coin,
+  token,
+  total,
+  hold: '0',
+});
+
+const clearinghouse = (accountValue: string, unrealizedPnls: string[] = []): ClearinghouseState => ({
+  assetPositions: unrealizedPnls.map((unrealizedPnl) => ({
+    position: { unrealizedPnl },
+  })),
+  crossMarginSummary: { accountValue },
+});
+
+const PURR: HypercoreSpotToken = {
+  type: TokenType.HYPERCORE_SPOT,
+  index: 5,
+  name: 'Purr',
+  symbol: 'PURR',
+  decimals: 6,
+  evmContract: '0xabc0000000000000000000000000000000000001',
+};
+
+const CORE_ONLY: HypercoreSpotToken = {
+  type: TokenType.HYPERCORE_SPOT,
+  index: 7,
+  name: 'Core Only',
+  symbol: 'CORE',
+  decimals: 4,
+};
+
+describe('spotCountsAsPerpCollateral', () => {
+  it('is true only for unifiedAccount', () => {
+    expect(spotCountsAsPerpCollateral('unifiedAccount')).toBe(true);
+    expect(spotCountsAsPerpCollateral('default')).toBe(false);
+    expect(spotCountsAsPerpCollateral('disabled')).toBe(false);
+    expect(spotCountsAsPerpCollateral(undefined)).toBe(false);
+  });
+});
+
+describe('getPerpCollateralUsd', () => {
+  it('excludes positive unrealized PnL from account value', () => {
+    expect(getPerpCollateralUsd(clearinghouse('50', ['10'])).toString()).toBe('40');
+  });
+
+  it('adds back losses so collateral reflects deposited margin', () => {
+    expect(getPerpCollateralUsd(clearinghouse('50', ['-10'])).toString()).toBe('60');
+  });
+
+  it('returns zero for no perp account', () => {
+    expect(getPerpCollateralUsd(undefined).toString()).toBe('0');
+  });
+
+  it('clamps negative collateral to zero', () => {
+    expect(getPerpCollateralUsd(clearinghouse('5', ['10'])).toString()).toBe('0');
+  });
+});
+
+describe('toHypercoreSpotTokens', () => {
+  it('maps spotMeta tokens and keeps valid EVM contract addresses', () => {
+    const tokens = toHypercoreSpotTokens([
+      {
+        name: 'PURR',
+        index: 5,
+        weiDecimals: 6,
+        fullName: 'Purr',
+        evmContract: {
+          address: '0xabc0000000000000000000000000000000000001',
+        },
+      },
+      {
+        name: 'CORE',
+        index: 7,
+        weiDecimals: 4,
+        fullName: null,
+      },
+    ]);
+
+    expect(tokens).toEqual([
+      {
+        type: TokenType.HYPERCORE_SPOT,
+        index: 5,
+        name: 'Purr',
+        symbol: 'PURR',
+        decimals: 6,
+        evmContract: '0xabc0000000000000000000000000000000000001',
+      },
+      {
+        type: TokenType.HYPERCORE_SPOT,
+        index: 7,
+        name: 'CORE',
+        symbol: 'CORE',
+        decimals: 4,
+        evmContract: undefined,
+      },
+    ]);
+  });
+});
+
+describe('buildHypercoreTokens', () => {
+  it('folds perp collateral (PnL excluded) into the USDC holding for default accounts', () => {
+    const tokens = buildHypercoreTokens({
+      spotBalances: [spotBalance('USDC', 0, '100')],
+      perpState: clearinghouse('50', ['10']),
+      abstractionMode: 'default',
+      spotTokens: [],
+    });
+
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]?.symbol).toBe('USDC');
+    expect(tokens[0]?.kind).toBe('native');
+    expect(tokens[0]?.balance).toBe('140');
+    expect(tokens[0]?.kind === 'native' && tokens[0].priceUsd).toBe(1);
+    expect(tokens[0]?.kind === 'native' && tokens[0].balanceUsd).toBe('140');
+  });
+
+  it('does NOT add perp collateral for unified accounts (spot already backs perps)', () => {
+    const tokens = buildHypercoreTokens({
+      spotBalances: [spotBalance('USDC', 0, '100')],
+      perpState: clearinghouse('50', ['10']),
+      abstractionMode: 'unifiedAccount',
+      spotTokens: [],
+    });
+
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]?.balance).toBe('100');
+  });
+
+  it('surfaces a USDC holding from perp collateral alone', () => {
+    const tokens = buildHypercoreTokens({
+      spotBalances: [],
+      perpState: clearinghouse('40'),
+      abstractionMode: 'default',
+      spotTokens: [],
+    });
+
+    expect(tokens.map((token) => token.symbol)).toEqual(['USDC']);
+    expect(tokens[0]?.balance).toBe('40');
+  });
+
+  it('omits USDC when neither spot nor collateral exist', () => {
+    const tokens = buildHypercoreTokens({
+      spotBalances: [spotBalance('PURR', 5, '12')],
+      perpState: undefined,
+      abstractionMode: 'default',
+      spotTokens: [PURR],
+    });
+
+    expect(tokens.map((token) => token.symbol)).toEqual(['PURR']);
+  });
+
+  it('maps spot tokens by index without synthesizing ERC20 addresses', () => {
+    const tokens = buildHypercoreTokens({
+      spotBalances: [spotBalance('PURR', 5, '12.5')],
+      perpState: undefined,
+      abstractionMode: 'default',
+      spotTokens: [PURR],
+    });
+
+    const purr = tokens[0];
+    expect(purr?.kind).toBe('spot');
+    expect(purr?.symbol).toBe('PURR');
+    expect(purr?.balance).toBe('12.5');
+    expect(purr?.kind === 'spot' && purr.index).toBe(5);
+    expect(purr?.kind === 'spot' && purr.evmContract).toBe(PURR.evmContract);
+  });
+
+  it('keeps HyperCore-only spot tokens without an evmContract', () => {
+    const tokens = buildHypercoreTokens({
+      spotBalances: [spotBalance('CORE', 7, '1')],
+      perpState: undefined,
+      abstractionMode: 'default',
+      spotTokens: [CORE_ONLY],
+    });
+
+    const core = tokens[0];
+    expect(core?.kind).toBe('spot');
+    expect(core?.kind === 'spot' && core.index).toBe(7);
+    expect(core?.kind === 'spot' && core.evmContract).toBeUndefined();
+  });
+
+  it('skips zero balances and tokens missing from the registry', () => {
+    const tokens = buildHypercoreTokens({
+      spotBalances: [spotBalance('PURR', 5, '0'), spotBalance('UNKNOWN', 99, '5')],
+      perpState: undefined,
+      abstractionMode: 'default',
+      spotTokens: [PURR],
+    });
+
+    expect(tokens).toHaveLength(0);
+  });
+});

--- a/packages/hypercore-module/src/utils/build-hypercore-tokens.ts
+++ b/packages/hypercore-module/src/utils/build-hypercore-tokens.ts
@@ -1,0 +1,121 @@
+import Big from 'big.js';
+import type { HypercoreSpotToken } from '@avalabs/vm-module-types';
+import { HYPERCORE_USDC_DECIMALS, HYPERCORE_USDC_NAME, HYPERCORE_USDC_SYMBOL } from '../constants';
+import type { ClearinghouseState, SpotBalance, UserAbstractionMode } from './schemas';
+
+const BIG_ZERO = new Big(0);
+
+export type HypercoreNativeTokenBalance = {
+  kind: 'native';
+  name: string;
+  symbol: typeof HYPERCORE_USDC_SYMBOL;
+  decimals: number;
+  /** Human-readable amount (decimal string). */
+  balance: string;
+  /** Integer raw amount as a decimal string (no fractional part). */
+  balanceRaw: string;
+  priceUsd: 1;
+  balanceUsd: string;
+};
+
+export type HypercoreSpotTokenBalance = {
+  kind: 'spot';
+  name: string;
+  symbol: string;
+  decimals: number;
+  balance: string;
+  balanceRaw: string;
+  index: number;
+  evmContract?: string;
+};
+
+export type HypercoreTokenBalance = HypercoreNativeTokenBalance | HypercoreSpotTokenBalance;
+
+/**
+ * `true` when spot balances already back perps for this account mode
+ * (`unifiedAccount`). Other modes keep perp collateral on a separate ledger.
+ */
+export const spotCountsAsPerpCollateral = (mode: UserAbstractionMode | undefined) => mode === 'unifiedAccount';
+
+/** Tokens carry no native gas balance on HyperCore — amounts are human decimals. */
+const toRawBalance = (humanAmount: Big, decimals: number) =>
+  humanAmount.times(new Big(10).pow(decimals)).round(0, Big.roundDown).toFixed(0);
+
+/**
+ * Perp collateral in USDC, excluding unrealized PnL.
+ * `crossMarginSummary.accountValue` is collateral ± PnL; we back PnL out.
+ */
+export const getPerpCollateralUsd = (perp: ClearinghouseState | undefined) => {
+  if (!perp) {
+    return BIG_ZERO;
+  }
+
+  const accountValue = new Big(perp.crossMarginSummary.accountValue ?? '0');
+  const unrealizedPnl = perp.assetPositions.reduce((sum, { position }) => sum.plus(position.unrealizedPnl), BIG_ZERO);
+  const collateral = accountValue.minus(unrealizedPnl);
+
+  return collateral.gt(BIG_ZERO) ? collateral : BIG_ZERO;
+};
+
+/**
+ * USDC merges spot + (non-unified) PnL-excluded perp collateral at $1.
+ * Other spot inventory is `HYPERCORE_SPOT` (no synthetic ERC20 addresses).
+ */
+export const buildHypercoreTokens = ({
+  spotBalances,
+  perpState,
+  abstractionMode,
+  spotTokens,
+}: {
+  spotBalances: readonly SpotBalance[];
+  perpState: ClearinghouseState | undefined;
+  abstractionMode: UserAbstractionMode | undefined;
+  spotTokens: HypercoreSpotToken[];
+}): HypercoreTokenBalance[] => {
+  const tokensByIndex = new Map(spotTokens.map((token) => [token.index, token]));
+
+  const perpCollateralUsd = spotCountsAsPerpCollateral(abstractionMode) ? BIG_ZERO : getPerpCollateralUsd(perpState);
+
+  const spotUsdc = spotBalances.find((balance) => balance.coin.toUpperCase() === HYPERCORE_USDC_SYMBOL);
+  const usdcTotal = new Big(spotUsdc?.total ?? '0').plus(perpCollateralUsd);
+
+  const tokens: HypercoreTokenBalance[] = [];
+
+  if (usdcTotal.gt(BIG_ZERO)) {
+    tokens.push({
+      kind: 'native',
+      name: HYPERCORE_USDC_NAME,
+      symbol: HYPERCORE_USDC_SYMBOL,
+      decimals: HYPERCORE_USDC_DECIMALS,
+      balance: usdcTotal.toString(),
+      balanceRaw: toRawBalance(usdcTotal, HYPERCORE_USDC_DECIMALS),
+      priceUsd: 1,
+      balanceUsd: usdcTotal.toString(),
+    });
+  }
+
+  for (const balance of spotBalances) {
+    if (balance.coin.toUpperCase() === HYPERCORE_USDC_SYMBOL) {
+      continue;
+    }
+
+    const meta = tokensByIndex.get(balance.token);
+    const total = new Big(balance.total);
+    if (!meta || !total.gt(BIG_ZERO)) {
+      continue;
+    }
+
+    tokens.push({
+      kind: 'spot',
+      name: meta.name,
+      symbol: meta.symbol,
+      decimals: meta.decimals,
+      balance: total.toString(),
+      balanceRaw: toRawBalance(total, meta.decimals),
+      index: meta.index,
+      evmContract: meta.evmContract,
+    });
+  }
+
+  return tokens;
+};

--- a/packages/hypercore-module/src/utils/hyperliquid-coin-svg-url.ts
+++ b/packages/hypercore-module/src/utils/hyperliquid-coin-svg-url.ts
@@ -1,0 +1,14 @@
+export const HYPERLIQUID_COIN_SVG_BASE = 'https://app.hyperliquid.xyz/coins';
+
+export const hyperliquidCoinSvgKey = (coin: string) => {
+  const trimmed = coin.trim();
+  const separatorIndex = trimmed.indexOf(':');
+  if (separatorIndex === -1) {
+    return trimmed.toUpperCase();
+  }
+  // HIP-3 logos are keyed as `marketname:TICKER` (dex prefix is case-significant).
+  return `${trimmed.slice(0, separatorIndex)}:${trimmed.slice(separatorIndex + 1).toUpperCase()}`;
+};
+
+export const hyperliquidCoinSvgUrl = (coin: string) =>
+  `${HYPERLIQUID_COIN_SVG_BASE}/${encodeURIComponent(hyperliquidCoinSvgKey(coin))}.svg`;

--- a/packages/hypercore-module/src/utils/info-client.ts
+++ b/packages/hypercore-module/src/utils/info-client.ts
@@ -43,7 +43,19 @@ export type PostInfoOptions = {
   url?: string;
 };
 
-const lowercaseUser = (user: string) => user.toLowerCase();
+const resolveFetch = (fetchFn?: typeof globalThis.fetch): typeof globalThis.fetch => {
+  if (typeof fetchFn === 'function') {
+    return fetchFn;
+  }
+
+  if (typeof globalThis.fetch === 'function') {
+    return globalThis.fetch.bind(globalThis);
+  }
+
+  throw new Error(
+    'HypercoreInfoClient requires a fetch implementation. Pass config.fetch when globalThis.fetch is unavailable (e.g. React Native).',
+  );
+};
 
 export class HypercoreInfoClient {
   readonly #infoUrl: string;
@@ -53,7 +65,7 @@ export class HypercoreInfoClient {
   constructor(config: HypercoreInfoClientConfig) {
     this.#infoUrl = config.infoUrl;
     this.#activityInfoUrl = config.activityInfoUrl ?? config.infoUrl;
-    this.#fetch = config.fetch ?? globalThis.fetch.bind(globalThis);
+    this.#fetch = resolveFetch(config.fetch);
   }
 
   async postInfo<T>(body: HypercoreInfoRequest, schema: z.ZodType<T>, options?: PostInfoOptions) {
@@ -80,7 +92,7 @@ export class HypercoreInfoClient {
     return this.postInfo(
       {
         type: 'spotClearinghouseState',
-        user: lowercaseUser(user),
+        user: user.toLowerCase(),
         dex: '',
       },
       spotClearinghouseStateSchema,
@@ -92,7 +104,7 @@ export class HypercoreInfoClient {
     return this.postInfo(
       {
         type: 'clearinghouseState',
-        user: lowercaseUser(user),
+        user: user.toLowerCase(),
         dex: '',
       },
       clearinghouseStateSchema,
@@ -102,14 +114,14 @@ export class HypercoreInfoClient {
 
   getUserAbstraction(user: string, options?: PostInfoOptions): Promise<UserAbstractionMode> {
     return this.postInfo(
-      { type: 'userAbstraction', user: lowercaseUser(user) },
+      { type: 'userAbstraction', user: user.toLowerCase() },
       userAbstractionSchema,
       options,
     ) as Promise<UserAbstractionMode>;
   }
 
   getUserFills(user: string, options?: PostInfoOptions): Promise<UserFill[]> {
-    return this.postInfo({ type: 'userFills', user: lowercaseUser(user) }, userFillsSchema, {
+    return this.postInfo({ type: 'userFills', user: user.toLowerCase() }, userFillsSchema, {
       ...options,
       url: options?.url ?? this.#activityInfoUrl,
     });
@@ -123,7 +135,7 @@ export class HypercoreInfoClient {
     return this.postInfo(
       {
         type: 'userNonFundingLedgerUpdates',
-        user: lowercaseUser(user),
+        user: user.toLowerCase(),
         startTime,
       },
       hypercoreLedgerUpdatesSchema,

--- a/packages/hypercore-module/src/utils/info-client.ts
+++ b/packages/hypercore-module/src/utils/info-client.ts
@@ -1,0 +1,136 @@
+import type { z } from 'zod';
+import {
+  clearinghouseStateSchema,
+  hypercoreLedgerUpdatesSchema,
+  spotClearinghouseStateSchema,
+  spotMetaResponseSchema,
+  userAbstractionSchema,
+  userFillsSchema,
+  type ClearinghouseState,
+  type HypercoreLedgerUpdate,
+  type SpotClearinghouseState,
+  type SpotMetaResponse,
+  type UserAbstractionMode,
+  type UserFill,
+} from './schemas';
+
+export type HypercoreInfoRequest =
+  | { type: 'spotMeta' }
+  | { type: 'spotClearinghouseState'; user: string; dex?: string }
+  | { type: 'clearinghouseState'; user: string; dex?: string }
+  | { type: 'userAbstraction'; user: string }
+  | { type: 'userFills'; user: string }
+  | {
+      type: 'userNonFundingLedgerUpdates';
+      user: string;
+      startTime: number;
+    };
+
+export type HypercoreInfoClientConfig = {
+  /** Proxy-first `/info` URL used for balances and spot meta. */
+  infoUrl: string;
+  /**
+   * Activity URL. Defaults to `infoUrl`; may be the public HL endpoint when
+   * the proxy does not yet support fills/ledger types.
+   */
+  activityInfoUrl?: string;
+  fetch?: typeof globalThis.fetch;
+};
+
+export type PostInfoOptions = {
+  signal?: AbortSignal;
+  /** Overrides the client default URL for this call. */
+  url?: string;
+};
+
+const lowercaseUser = (user: string) => user.toLowerCase();
+
+export class HypercoreInfoClient {
+  readonly #infoUrl: string;
+  readonly #activityInfoUrl: string;
+  readonly #fetch: typeof globalThis.fetch;
+
+  constructor(config: HypercoreInfoClientConfig) {
+    this.#infoUrl = config.infoUrl;
+    this.#activityInfoUrl = config.activityInfoUrl ?? config.infoUrl;
+    this.#fetch = config.fetch ?? globalThis.fetch.bind(globalThis);
+  }
+
+  async postInfo<T>(body: HypercoreInfoRequest, schema: z.ZodType<T>, options?: PostInfoOptions) {
+    const response = await this.#fetch(options?.url ?? this.#infoUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: options?.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Hyperliquid /info failed: ${response.status} ${response.statusText}`);
+    }
+
+    const json: unknown = await response.json();
+    return schema.parse(json);
+  }
+
+  getSpotMeta(options?: PostInfoOptions): Promise<SpotMetaResponse> {
+    return this.postInfo({ type: 'spotMeta' }, spotMetaResponseSchema, options);
+  }
+
+  getSpotClearinghouseState(user: string, options?: PostInfoOptions): Promise<SpotClearinghouseState> {
+    return this.postInfo(
+      {
+        type: 'spotClearinghouseState',
+        user: lowercaseUser(user),
+        dex: '',
+      },
+      spotClearinghouseStateSchema,
+      options,
+    ) as Promise<SpotClearinghouseState>;
+  }
+
+  getClearinghouseState(user: string, options?: PostInfoOptions): Promise<ClearinghouseState> {
+    return this.postInfo(
+      {
+        type: 'clearinghouseState',
+        user: lowercaseUser(user),
+        dex: '',
+      },
+      clearinghouseStateSchema,
+      options,
+    );
+  }
+
+  getUserAbstraction(user: string, options?: PostInfoOptions): Promise<UserAbstractionMode> {
+    return this.postInfo(
+      { type: 'userAbstraction', user: lowercaseUser(user) },
+      userAbstractionSchema,
+      options,
+    ) as Promise<UserAbstractionMode>;
+  }
+
+  getUserFills(user: string, options?: PostInfoOptions): Promise<UserFill[]> {
+    return this.postInfo({ type: 'userFills', user: lowercaseUser(user) }, userFillsSchema, {
+      ...options,
+      url: options?.url ?? this.#activityInfoUrl,
+    });
+  }
+
+  getUserNonFundingLedgerUpdates(
+    user: string,
+    startTime: number,
+    options?: PostInfoOptions,
+  ): Promise<HypercoreLedgerUpdate[]> {
+    return this.postInfo(
+      {
+        type: 'userNonFundingLedgerUpdates',
+        user: lowercaseUser(user),
+        startTime,
+      },
+      hypercoreLedgerUpdatesSchema,
+      {
+        ...options,
+        url: options?.url ?? this.#activityInfoUrl,
+      },
+    );
+  }
+}

--- a/packages/hypercore-module/src/utils/schemas.ts
+++ b/packages/hypercore-module/src/utils/schemas.ts
@@ -1,0 +1,128 @@
+import { z } from 'zod';
+
+const tokenIndexSchema = z.coerce.number();
+
+/** `type: "spotMeta"` — registry mapping spot token index → display metadata. */
+export const spotMetaResponseSchema = z.object({
+  tokens: z.array(
+    z.object({
+      name: z.string(),
+      index: z.number(),
+      weiDecimals: z.number(),
+      fullName: z.string().nullish(),
+      evmContract: z.object({ address: z.string() }).nullish(),
+    }),
+  ),
+});
+
+const spotBalanceSchema = z.object({
+  coin: z.string(),
+  token: tokenIndexSchema,
+  total: z.string(),
+  hold: z.string(),
+  entryNtl: z.string().optional(),
+});
+
+/** `type: "spotClearinghouseState"` */
+export const spotClearinghouseStateSchema = z.object({
+  balances: z.array(spotBalanceSchema),
+});
+
+const marginSummarySchema = z.object({
+  accountValue: z.string(),
+  totalMarginUsed: z.string().optional(),
+  totalNtlPos: z.string().optional(),
+  totalRawUsd: z.string().optional(),
+});
+
+/**
+ * `type: "clearinghouseState"` — only fields needed for PnL-excluded
+ * perp collateral fold-in.
+ */
+export const clearinghouseStateSchema = z.object({
+  assetPositions: z.array(
+    z.object({
+      position: z.object({
+        unrealizedPnl: z.string(),
+      }),
+    }),
+  ),
+  crossMarginSummary: marginSummarySchema,
+});
+
+export type UserAbstractionMode = 'unifiedAccount' | 'portfolioMargin' | 'dexAbstraction' | 'disabled' | 'default';
+
+/**
+ * `type: "userAbstraction"` — bare JSON string. Unknown future values coerce
+ * to `"default"` so balance math stays conservative.
+ */
+export const userAbstractionSchema = z.string().transform((value): UserAbstractionMode => {
+  switch (value) {
+    case 'unifiedAccount':
+    case 'portfolioMargin':
+    case 'dexAbstraction':
+    case 'disabled':
+    case 'default':
+      return value;
+    default:
+      return 'default';
+  }
+});
+
+/** `type: "userFills"` */
+export const userFillSchema = z.object({
+  closedPnl: z.string(),
+  coin: z.string(),
+  crossed: z.boolean(),
+  dir: z.string(),
+  hash: z.string(),
+  oid: z.number(),
+  px: z.string(),
+  side: z.string(),
+  startPosition: z.string(),
+  sz: z.string(),
+  time: z.number(),
+  fee: z.string().optional(),
+  tid: z.number().optional(),
+});
+
+export const userFillsSchema = z.array(userFillSchema);
+
+/**
+ * `userNonFundingLedgerUpdates` deltas — permissive so unknown delta types
+ * still parse and can render generically later.
+ */
+export const hypercoreLedgerDeltaSchema = z.object({
+  type: z.string(),
+  usdc: z.string().optional(),
+  amount: z.string().optional(),
+  usdcValue: z.string().optional(),
+  token: z.string().optional(),
+  user: z.string().optional(),
+  destination: z.string().optional(),
+  fee: z.string().optional(),
+  toPerp: z.boolean().optional(),
+});
+
+export const hypercoreLedgerUpdateSchema = z.object({
+  time: z.number(),
+  hash: z.string(),
+  delta: hypercoreLedgerDeltaSchema,
+});
+
+export const hypercoreLedgerUpdatesSchema = z.array(hypercoreLedgerUpdateSchema);
+
+export type SpotMetaResponse = z.infer<typeof spotMetaResponseSchema>;
+export type SpotBalance = {
+  coin: string;
+  token: number;
+  total: string;
+  hold: string;
+  entryNtl?: string;
+};
+export type SpotClearinghouseState = {
+  balances: SpotBalance[];
+};
+export type ClearinghouseState = z.infer<typeof clearinghouseStateSchema>;
+export type UserFill = z.infer<typeof userFillSchema>;
+export type HypercoreLedgerUpdate = z.infer<typeof hypercoreLedgerUpdateSchema>;

--- a/packages/hypercore-module/src/utils/spot-tokens.ts
+++ b/packages/hypercore-module/src/utils/spot-tokens.ts
@@ -1,0 +1,22 @@
+import { TokenType, type HypercoreSpotToken } from '@avalabs/vm-module-types';
+import type { SpotMetaResponse } from './schemas';
+
+const isValidEvmAddress = (address: string) => /^0x[a-fA-F0-9]{40}$/.test(address);
+
+/**
+ * Maps `spotMeta` tokens to the registry used when resolving spot balances.
+ * Keeps every spot token (including HyperCore-only ones without an EVM contract).
+ */
+export const toHypercoreSpotTokens = (tokens: SpotMetaResponse['tokens']): HypercoreSpotToken[] =>
+  tokens.map((token) => {
+    const address = token.evmContract?.address.toLowerCase();
+
+    return {
+      type: TokenType.HYPERCORE_SPOT,
+      index: token.index,
+      name: token.fullName ?? token.name,
+      symbol: token.name,
+      decimals: token.weiDecimals,
+      evmContract: address && isValidEvmAddress(address) ? address : undefined,
+    };
+  });

--- a/packages/hypercore-module/src/utils/unsupported.ts
+++ b/packages/hypercore-module/src/utils/unsupported.ts
@@ -1,0 +1,10 @@
+/**
+ * Loud failure message for HyperCore capabilities that do not exist (no RPC, no gas).
+ * Prefer rejecting with this over empty success so clients and agents see intentional gaps.
+ */
+export const unsupportedHypercoreCapabilityMessage = (capability: string) =>
+  `HyperCore does not support ${capability}: read-only module (balances, tokens, activity).`;
+
+export const unsupportedHypercoreCapability = (capability: string): never => {
+  throw new Error(unsupportedHypercoreCapabilityMessage(capability));
+};

--- a/packages/hypercore-module/tsconfig.jest.json
+++ b/packages/hypercore-module/tsconfig.jest.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "verbatimModuleSyntax": false,
+    "esModuleInterop": true
+  }
+}

--- a/packages/hypercore-module/tsconfig.json
+++ b/packages/hypercore-module/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@internal/tsconfig/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "declaration": false,
+    "incremental": false
+  },
+  "include": ["src", "tsconfig.test.json"],
+  "references": [
+    {
+      "path": "../../packages-internal/utils/tsconfig.json"
+    }
+  ]
+}

--- a/packages/hypercore-module/tsup.config.ts
+++ b/packages/hypercore-module/tsup.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig } from 'tsup';
+import { baseConfig } from '@internal/tsup-config';
+
+export default defineConfig(baseConfig);

--- a/packages/types/src/balance.ts
+++ b/packages/types/src/balance.ts
@@ -71,6 +71,19 @@ export type TokenWithBalanceSPL = TokenBalanceDataWithDecimals &
     reputation: null;
   };
 
+/**
+ * HyperCore spot TokenWithBalance. Identity is spot `index`, not an EVM address.
+ */
+export type TokenWithBalanceHypercoreSpot = TokenBalanceDataWithDecimals &
+  TokenMarketData & {
+    type: TokenType.HYPERCORE_SPOT;
+    index: number;
+    logoUri?: string;
+    reputation: null;
+    /** Optional HyperEVM bridge contract when the spot asset is bridged. */
+    evmContract?: string;
+  };
+
 export type TokenWithBalanceEVM = NetworkTokenWithBalance | TokenWithBalanceERC20 | NftTokenWithBalance;
 
 /**
@@ -180,6 +193,7 @@ export type TokenWithBalance =
   | TokenWithBalancePVM
   | TokenWithBalanceAVM
   | TokenWithBalanceSVM
-  | TokenWithBalanceSPL;
+  | TokenWithBalanceSPL
+  | TokenWithBalanceHypercoreSpot;
 
 export type GetBalancesResponse = Record<string, Record<string, TokenWithBalance | Error> | Error>;

--- a/packages/types/src/common.ts
+++ b/packages/types/src/common.ts
@@ -33,6 +33,7 @@ export enum NetworkVMType {
   CoreEth = 'CoreEth',
   HVM = 'HVM',
   SVM = 'SVM',
+  HYPERCORE = 'HYPERCORE',
 }
 
 export type Storage = {

--- a/packages/types/src/module.ts
+++ b/packages/types/src/module.ts
@@ -14,7 +14,7 @@ import { AppName, Environment, type Network } from './common';
 import type { Manifest } from './manifest';
 import type { NetworkFees } from './network-fee';
 import type { RpcRequest, RpcResponse } from './rpc';
-import type { NetworkContractToken } from './token';
+import type { NetworkContractToken, HypercoreSpotToken } from './token';
 import type { GetTransactionHistory, TransactionHistoryResponse } from './transaction-history';
 import type { ApprovalController } from './rpc';
 import type { HyperSDKClient } from 'hypersdk-client';
@@ -54,6 +54,6 @@ export interface Module {
   deriveAddress: (params: DeriveAddressParams) => Promise<DeriveAddressResponse>;
   deriveAddresses: (params: DeriveAddressesParams) => Promise<DeriveAddressesResponse>;
   buildDerivationPath: (params: BuildDerivationPathParams) => BuildDerivationPathResponse;
-  getTokens: (network: Network) => Promise<NetworkContractToken[]>;
+  getTokens: (network: Network) => Promise<(NetworkContractToken | HypercoreSpotToken)[]>;
   onRpcRequest: (request: RpcRequest, chain: Network) => Promise<RpcResponse>;
 }

--- a/packages/types/src/token.ts
+++ b/packages/types/src/token.ts
@@ -5,6 +5,7 @@ export enum TokenType {
   ERC1155 = 'ERC1155',
   NONERC = 'NONERC',
   SPL = 'SPL',
+  HYPERCORE_SPOT = 'HYPERCORE_SPOT',
 }
 
 export interface NetworkToken {
@@ -65,4 +66,19 @@ export interface NONERCToken {
   logoUri?: string;
   name?: string;
   symbol?: string;
+}
+
+/**
+ * HyperCore spot token. Identity is the Hyperliquid spot `index`, not an EVM
+ * contract. `evmContract` is present only when the asset is bridged to HyperEVM.
+ */
+export interface HypercoreSpotToken {
+  type: TokenType.HYPERCORE_SPOT;
+  index: number;
+  name: string;
+  symbol: string;
+  decimals: number;
+  logoUri?: string;
+  /** Optional HyperEVM bridge contract; not required for HyperCore-only spot. */
+  evmContract?: string;
 }

--- a/packages/types/src/transaction-history.ts
+++ b/packages/types/src/transaction-history.ts
@@ -49,6 +49,12 @@ export type TxToken = {
   | {
       type: TokenType.NATIVE;
     }
+  | {
+      type: TokenType.HYPERCORE_SPOT;
+      index: number;
+      /** Optional HyperEVM bridge contract when the spot asset is bridged. */
+      evmContract?: string;
+    }
 );
 
 // this is RichAddress from @avalabs/glacier-sdk,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,7 +134,7 @@ importers:
         version: 29.7.0(@types/node@25.0.6)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
+        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(esbuild@0.18.20)(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -207,7 +207,7 @@ importers:
         version: 29.7.0(@types/node@25.0.6)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
+        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(esbuild@0.18.20)(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
       tsup:
         specifier: 7.2.0
         version: 7.2.0(typescript@5.8.2)
@@ -268,7 +268,7 @@ importers:
         version: 29.7.0(@types/node@25.0.6)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
+        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(esbuild@0.18.20)(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
       tsup:
         specifier: 7.2.0
         version: 7.2.0(typescript@5.8.2)
@@ -356,7 +356,7 @@ importers:
         version: 29.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
+        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(esbuild@0.18.20)(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
       tsup:
         specifier: 7.2.0
         version: 7.2.0(typescript@5.8.2)
@@ -414,7 +414,56 @@ importers:
         version: 29.7.0(@types/node@25.0.6)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
+        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(esbuild@0.18.20)(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
+      tsup:
+        specifier: 7.2.0
+        version: 7.2.0(typescript@5.8.2)
+
+  packages/hypercore-module:
+    dependencies:
+      '@avalabs/core-wallets-sdk':
+        specifier: 3.1.0-alpha.87
+        version: 3.1.0-alpha.87(@solana/sysvars@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))(big.js@6.2.1)(bn.js@5.2.2)(ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(node-fetch@2.7.0)(react@18.3.1)(typescript@5.8.2)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@avalabs/crypto-sdk':
+        specifier: 1.0.0
+        version: 1.0.0
+      '@avalabs/vm-module-types':
+        specifier: workspace:*
+        version: link:../types
+      '@metamask/rpc-errors':
+        specifier: 6.3.0
+        version: 6.3.0
+      big.js:
+        specifier: 6.2.1
+        version: 6.2.1
+      zod:
+        specifier: 3.23.8
+        version: 3.23.8
+    devDependencies:
+      '@internal/tsup-config':
+        specifier: workspace:*
+        version: link:../../packages-internal/tsup-config
+      '@internal/utils':
+        specifier: workspace:*
+        version: link:../../packages-internal/utils
+      '@types/big.js':
+        specifier: 6.2.2
+        version: 6.2.2
+      '@types/jest':
+        specifier: 29.5.7
+        version: 29.5.7
+      eslint-config-custom:
+        specifier: workspace:*
+        version: link:../../packages-internal/eslint-config-custom
+      ethers:
+        specifier: 6.13.5
+        version: 6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@25.0.6)
+      ts-jest:
+        specifier: 29.1.1
+        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(esbuild@0.18.20)(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
       tsup:
         specifier: 7.2.0
         version: 7.2.0(typescript@5.8.2)
@@ -493,7 +542,7 @@ importers:
         version: 29.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
+        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(esbuild@0.18.20)(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
       tsup:
         specifier: 7.2.0
         version: 7.2.0(typescript@5.8.2)
@@ -1808,6 +1857,7 @@ packages:
 
   '@metamask/sdk-communication-layer@0.29.2':
     resolution: {integrity: sha512-Xfa1DXOg0bfvMqXa3o/Y43bm2kHYyD4YdR0XiuhL70NJzPcUPM53I1O7aSg83ogRHsHI4LM7dEEMEo6w6uQgdg==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
     peerDependencies:
       cross-fetch: ^4.0.0
       eciesjs: ^0.3.16
@@ -1817,6 +1867,7 @@ packages:
 
   '@metamask/sdk-install-modal-web@0.29.2':
     resolution: {integrity: sha512-AOiRpv0pIxIyWYTuBWRymdTVwdZrsVNGNFv0I7RlBU0s1hQ6lapEq2eeIv30d9E88mS/DI6F3R0ArSg0So7W2g==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
     peerDependencies:
       i18next: 23.11.5
       react: ^18.2.0
@@ -1832,6 +1883,7 @@ packages:
 
   '@metamask/sdk@0.29.3':
     resolution: {integrity: sha512-raOqMlsEjzsz3bOAK1x7/1QyGfnCyGvFZOT4OYoyepKu3QG3ex3o8iHdVYlcMkqZVcOsXWLsrUorn0SYploXyw==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
     peerDependencies:
       react: ^18.2.0
       react-dom: ^18.2.0
@@ -3902,11 +3954,11 @@ packages:
 
   glob@7.1.7:
     resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
@@ -4577,6 +4629,7 @@ packages:
   ledger-bitcoin@0.2.3:
     resolution: {integrity: sha512-sWdvMTR5CkebNlM0Mam9ROdpsD7Y4087kj4cbIaCCq8IXShCQ44vE3j0wTmt+sHp13eETgY63OWN1rkuIfMfuQ==}
     engines: {node: '>=14'}
+    deprecated: Please use @ledgerhq/ledger-bitcoin
 
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -6111,10 +6164,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@9.3.0:
@@ -13401,7 +13456,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2):
+  ts-jest@29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(esbuild@0.18.20)(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -13417,6 +13472,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.28.5)
+      esbuild: 0.18.20
 
   tsconfig-paths@3.15.0:
     dependencies:


### PR DESCRIPTION
## Changes
- Adds new `hypercore-module` (moved over utils/helpers moved over from https://github.com/ava-labs/core-extension/pull/983)
- Registers read-only HyperCore on CAIP hlcore:mainnet (balances, tokens, activity; no dapp RPC / send)
- Extends @avalabs/vm-module-types with NetworkVMType.HYPERCORE and others
- Implements EVM-style address derivation keyed as `HYPERCORE` (same 0x address as addressC)