### PR TITLE
feat: add hyperevm scan transactions support

### DIFF
--- a/.changeset/support-hyperevm.md
+++ b/.changeset/support-hyperevm.md
@@ -1,0 +1,5 @@
+---
+'@avalabs/evm-module': minor
+---
+
+Add HyperEVM scan compatible transaction history support.

--- a/packages/evm-module/src/handlers/get-transaction-history/converters/hyperevm-transaction-converter/get-transactions-from-hyperevm.test.ts
+++ b/packages/evm-module/src/handlers/get-transaction-history/converters/hyperevm-transaction-converter/get-transactions-from-hyperevm.test.ts
@@ -56,6 +56,7 @@ describe('getTransactionsFromHyperEvm', () => {
 
     const result = await getTransactionsFromHyperEvm({
       client,
+      chainId: 999,
       networkToken: { name: 'Hyperliquid', symbol: 'HYPE', decimals: 18 },
       explorerUrl: 'https://hyperevmscan.io',
       address: '0xwallet',
@@ -66,6 +67,7 @@ describe('getTransactionsFromHyperEvm', () => {
       transactions: [
         expect.objectContaining({
           hash: '0xswap',
+          chainId: '999',
           txType: TransactionType.SWAP,
           isContractCall: true,
           explorerLink: 'https://hyperevmscan.io/tx/0xswap',
@@ -73,5 +75,25 @@ describe('getTransactionsFromHyperEvm', () => {
         }),
       ],
     });
+  });
+
+  it('uses the first page for an invalid page token', async () => {
+    const client = {
+      listNormalTransactions: jest.fn().mockResolvedValue([]),
+      listErc20Transfers: jest.fn().mockResolvedValue([]),
+      listInternalTransactions: jest.fn().mockResolvedValue([]),
+    };
+
+    const result = await getTransactionsFromHyperEvm({
+      client,
+      chainId: 999,
+      networkToken: { name: 'Hyperliquid', symbol: 'HYPE', decimals: 18 },
+      explorerUrl: 'https://hyperevmscan.io',
+      address: '0xwallet',
+      nextPageToken: 'not-a-page',
+    });
+
+    expect(client.listNormalTransactions).toHaveBeenCalledWith('0xwallet', { page: 1, offset: 25 });
+    expect(result).toEqual({ transactions: [], nextPageToken: '' });
   });
 });

--- a/packages/evm-module/src/handlers/get-transaction-history/converters/hyperevm-transaction-converter/get-transactions-from-hyperevm.test.ts
+++ b/packages/evm-module/src/handlers/get-transaction-history/converters/hyperevm-transaction-converter/get-transactions-from-hyperevm.test.ts
@@ -1,0 +1,77 @@
+import { TransactionType } from '@avalabs/vm-module-types';
+import { getTransactionsFromHyperEvm } from './get-transactions-from-hyperevm';
+
+const normal = {
+  blockNumber: '1',
+  timeStamp: '100',
+  hash: '0xswap',
+  nonce: '0',
+  blockHash: '0xblock',
+  transactionIndex: '0',
+  from: '0xwallet',
+  to: '0xrouter',
+  value: '0',
+  gas: '1',
+  gasPrice: '2',
+  isError: '0',
+  txreceipt_status: '1',
+  input: '0xabcdef',
+  contractAddress: '',
+  cumulativeGasUsed: '1',
+  gasUsed: '1',
+  confirmations: '1',
+};
+
+const transfer = (from: string, to: string, symbol: string) => ({
+  blockNumber: '1',
+  timeStamp: '100',
+  hash: '0xswap',
+  nonce: '0',
+  blockHash: '0xblock',
+  from,
+  contractAddress: '0x0000000000000000000000000000000000000001',
+  to,
+  value: '1000000',
+  tokenName: symbol,
+  tokenSymbol: symbol,
+  tokenDecimal: '6',
+  transactionIndex: '0',
+  gas: '1',
+  gasPrice: '2',
+  gasUsed: '1',
+  cumulativeGasUsed: '1',
+  input: '0x',
+  confirmations: '1',
+});
+
+describe('getTransactionsFromHyperEvm', () => {
+  it('aggregates ERC-20 legs by hash into an enriched swap transaction', async () => {
+    const client = {
+      listNormalTransactions: jest.fn().mockResolvedValue([normal]),
+      listErc20Transfers: jest
+        .fn()
+        .mockResolvedValue([transfer('0xwallet', '0xpool', 'USDC'), transfer('0xpool', '0xwallet', 'PURR')]),
+      listInternalTransactions: jest.fn().mockResolvedValue([]),
+    };
+
+    const result = await getTransactionsFromHyperEvm({
+      client,
+      networkToken: { name: 'Hyperliquid', symbol: 'HYPE', decimals: 18 },
+      explorerUrl: 'https://hyperevmscan.io',
+      address: '0xwallet',
+    });
+
+    expect(result).toEqual({
+      nextPageToken: '',
+      transactions: [
+        expect.objectContaining({
+          hash: '0xswap',
+          txType: TransactionType.SWAP,
+          isContractCall: true,
+          explorerLink: 'https://hyperevmscan.io/tx/0xswap',
+          tokens: [expect.objectContaining({ symbol: 'USDC' }), expect.objectContaining({ symbol: 'PURR' })],
+        }),
+      ],
+    });
+  });
+});

--- a/packages/evm-module/src/handlers/get-transaction-history/converters/hyperevm-transaction-converter/get-transactions-from-hyperevm.ts
+++ b/packages/evm-module/src/handlers/get-transaction-history/converters/hyperevm-transaction-converter/get-transactions-from-hyperevm.ts
@@ -1,0 +1,181 @@
+import { TokenUnit } from '@avalabs/core-utils-sdk';
+import {
+  TokenType,
+  TransactionType,
+  type NetworkToken,
+  type Transaction,
+  type TransactionHistoryResponse,
+  type TxToken,
+} from '@avalabs/vm-module-types';
+import type {
+  HyperEvmErc20Transfer,
+  HyperEvmEtherscanClient,
+  HyperEvmInternalTransaction,
+  HyperEvmNormalTransaction,
+} from '../../../../services/hyperevm-etherscan-client/hyperevm-etherscan-client';
+import { getExplorerAddressByNetwork } from '../../utils/get-explorer-address-by-network';
+
+type Aggregate = {
+  hash: string;
+  timestamp: number;
+  from: string;
+  to: string;
+  gasPrice?: string;
+  gasUsed: string;
+  isContractCall: boolean;
+  tokens: TxToken[];
+};
+
+export async function getTransactionsFromHyperEvm({
+  client,
+  networkToken,
+  explorerUrl,
+  address,
+  nextPageToken,
+  offset = 25,
+}: {
+  client: Pick<HyperEvmEtherscanClient, 'listNormalTransactions' | 'listErc20Transfers' | 'listInternalTransactions'>;
+  networkToken: NetworkToken;
+  explorerUrl: string;
+  address: string;
+  nextPageToken?: string;
+  offset?: number;
+}): Promise<TransactionHistoryResponse> {
+  try {
+    const page = Number(nextPageToken || '1');
+    const [normal, erc20, internal] = await Promise.all([
+      client.listNormalTransactions(address, { page, offset }),
+      client.listErc20Transfers(address, { page, offset }),
+      client.listInternalTransactions(address, { page, offset }),
+    ]);
+    const aggregates = new Map<string, Aggregate>();
+
+    for (const transaction of normal) {
+      if (transaction.isError !== '0' || transaction.txreceipt_status !== '1') continue;
+      const aggregate = getAggregate(aggregates, transaction);
+      const token = nativeToken(transaction, networkToken);
+      if (token) aggregate.tokens.push(token);
+    }
+    for (const transfer of erc20) {
+      const aggregate = getAggregate(aggregates, transfer);
+      aggregate.tokens.push(erc20Token(transfer));
+    }
+    for (const transaction of internal) {
+      if (transaction.isError !== '0') continue;
+      const aggregate = getAggregate(aggregates, transaction);
+      const token = internalToken(transaction, networkToken);
+      if (token) aggregate.tokens.push(token);
+    }
+
+    const transactions = Array.from(aggregates.values())
+      .map((aggregate) => toTransaction(aggregate, address, explorerUrl, networkToken))
+      .sort((a, b) => b.timestamp - a.timestamp);
+    const hasNextPage = [normal, erc20, internal].some((list) => list.length === offset);
+
+    return { transactions, nextPageToken: hasNextPage ? String(page + 1) : '' };
+  } catch {
+    return { transactions: [], nextPageToken: '' };
+  }
+}
+
+function getAggregate(
+  aggregates: Map<string, Aggregate>,
+  transaction: HyperEvmNormalTransaction | HyperEvmErc20Transfer | HyperEvmInternalTransaction,
+): Aggregate {
+  const existing = aggregates.get(transaction.hash);
+  if (existing) return existing;
+
+  const aggregate: Aggregate = {
+    hash: transaction.hash,
+    timestamp: Number(transaction.timeStamp) * 1000,
+    from: transaction.from,
+    to: transaction.to,
+    gasPrice: 'gasPrice' in transaction ? transaction.gasPrice : undefined,
+    gasUsed: transaction.gasUsed,
+    isContractCall: 'input' in transaction && transaction.input !== '0x',
+    tokens: [],
+  };
+  aggregates.set(transaction.hash, aggregate);
+  return aggregate;
+}
+
+function nativeToken(transaction: HyperEvmNormalTransaction, networkToken: NetworkToken): TxToken | undefined {
+  if (transaction.value === '0') return undefined;
+  return {
+    decimal: String(networkToken.decimals),
+    name: networkToken.name,
+    symbol: networkToken.symbol,
+    amount: new TokenUnit(transaction.value, networkToken.decimals, networkToken.symbol).toDisplay(),
+    from: { address: transaction.from },
+    to: { address: transaction.to },
+    type: TokenType.NATIVE,
+  };
+}
+
+function internalToken(transaction: HyperEvmInternalTransaction, networkToken: NetworkToken): TxToken | undefined {
+  if (transaction.value === '0') return undefined;
+  return {
+    decimal: String(networkToken.decimals),
+    name: networkToken.name,
+    symbol: networkToken.symbol,
+    amount: new TokenUnit(transaction.value, networkToken.decimals, networkToken.symbol).toDisplay(),
+    from: { address: transaction.from },
+    to: { address: transaction.to },
+    type: TokenType.NATIVE,
+  };
+}
+
+function erc20Token(transfer: HyperEvmErc20Transfer): TxToken {
+  return {
+    decimal: transfer.tokenDecimal,
+    name: transfer.tokenName,
+    symbol: transfer.tokenSymbol,
+    amount: new TokenUnit(transfer.value, Number(transfer.tokenDecimal), transfer.tokenSymbol).toDisplay(),
+    from: { address: transfer.from },
+    to: { address: transfer.to },
+    type: TokenType.ERC20,
+    address: transfer.contractAddress,
+  };
+}
+
+function toTransaction(
+  aggregate: Aggregate,
+  address: string,
+  explorerUrl: string,
+  networkToken: NetworkToken,
+): Transaction {
+  const wallet = address.toLowerCase();
+  const hasIncoming = aggregate.tokens.some((token) => token.to?.address.toLowerCase() === wallet);
+  const hasOutgoing = aggregate.tokens.some((token) => token.from?.address.toLowerCase() === wallet);
+  const isSender = aggregate.from.toLowerCase() === wallet || hasOutgoing;
+  const txType =
+    hasIncoming && hasOutgoing ? TransactionType.SWAP : isSender ? TransactionType.SEND : TransactionType.RECEIVE;
+
+  return {
+    isContractCall: aggregate.isContractCall || (hasIncoming && hasOutgoing),
+    isIncoming: hasIncoming && !hasOutgoing,
+    isOutgoing: hasOutgoing,
+    isSender,
+    timestamp: aggregate.timestamp,
+    hash: aggregate.hash,
+    from: aggregate.from,
+    to: aggregate.to,
+    tokens:
+      aggregate.tokens.length > 0
+        ? aggregate.tokens
+        : [
+            {
+              decimal: String(networkToken.decimals),
+              name: networkToken.name,
+              symbol: networkToken.symbol,
+              amount: '0',
+              type: TokenType.NATIVE,
+            },
+          ],
+    gasPrice: aggregate.gasPrice,
+    gasUsed: aggregate.gasUsed,
+    chainId: '999',
+    txType,
+    explorerLink: getExplorerAddressByNetwork(explorerUrl, aggregate.hash),
+  };
+}

--- a/packages/evm-module/src/handlers/get-transaction-history/converters/hyperevm-transaction-converter/get-transactions-from-hyperevm.ts
+++ b/packages/evm-module/src/handlers/get-transaction-history/converters/hyperevm-transaction-converter/get-transactions-from-hyperevm.ts
@@ -28,6 +28,7 @@ type Aggregate = {
 
 export async function getTransactionsFromHyperEvm({
   client,
+  chainId,
   networkToken,
   explorerUrl,
   address,
@@ -35,6 +36,7 @@ export async function getTransactionsFromHyperEvm({
   offset = 25,
 }: {
   client: Pick<HyperEvmEtherscanClient, 'listNormalTransactions' | 'listErc20Transfers' | 'listInternalTransactions'>;
+  chainId: number;
   networkToken: NetworkToken;
   explorerUrl: string;
   address: string;
@@ -42,7 +44,7 @@ export async function getTransactionsFromHyperEvm({
   offset?: number;
 }): Promise<TransactionHistoryResponse> {
   try {
-    const page = Number(nextPageToken || '1');
+    const page = getPage(nextPageToken);
     const [normal, erc20, internal] = await Promise.all([
       client.listNormalTransactions(address, { page, offset }),
       client.listErc20Transfers(address, { page, offset }),
@@ -68,7 +70,7 @@ export async function getTransactionsFromHyperEvm({
     }
 
     const transactions = Array.from(aggregates.values())
-      .map((aggregate) => toTransaction(aggregate, address, explorerUrl, networkToken))
+      .map((aggregate) => toTransaction(aggregate, address, explorerUrl, networkToken, chainId))
       .sort((a, b) => b.timestamp - a.timestamp);
     const hasNextPage = [normal, erc20, internal].some((list) => list.length === offset);
 
@@ -76,6 +78,11 @@ export async function getTransactionsFromHyperEvm({
   } catch {
     return { transactions: [], nextPageToken: '' };
   }
+}
+
+function getPage(nextPageToken?: string): number {
+  const page = Number(nextPageToken);
+  return Number.isSafeInteger(page) && page > 0 ? page : 1;
 }
 
 function getAggregate(
@@ -143,6 +150,7 @@ function toTransaction(
   address: string,
   explorerUrl: string,
   networkToken: NetworkToken,
+  chainId: number,
 ): Transaction {
   const wallet = address.toLowerCase();
   const hasIncoming = aggregate.tokens.some((token) => token.to?.address.toLowerCase() === wallet);
@@ -174,7 +182,7 @@ function toTransaction(
           ],
     gasPrice: aggregate.gasPrice,
     gasUsed: aggregate.gasUsed,
-    chainId: '999',
+    chainId: chainId.toString(),
     txType,
     explorerLink: getExplorerAddressByNetwork(explorerUrl, aggregate.hash),
   };

--- a/packages/evm-module/src/handlers/get-transaction-history/get-transaction-history.test.ts
+++ b/packages/evm-module/src/handlers/get-transaction-history/get-transaction-history.test.ts
@@ -32,7 +32,11 @@ describe('get-transaction-history', () => {
       address: '0xaddress',
     });
 
-    expect(getTransactionsFromHyperEvm).toHaveBeenCalled();
+    expect(getTransactionsFromHyperEvm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chainId: 999,
+      }),
+    );
     expect(getTransactionsFromGlacier).not.toHaveBeenCalled();
   });
 

--- a/packages/evm-module/src/handlers/get-transaction-history/get-transaction-history.test.ts
+++ b/packages/evm-module/src/handlers/get-transaction-history/get-transaction-history.test.ts
@@ -1,7 +1,9 @@
 import { getTransactionHistory } from './get-transaction-history';
 import { getTransactionsFromMoralis } from './converters/moralis-transaction-converter/get-transactions-from-moralis';
 import { getTransactionsFromGlacier } from './converters/evm-transaction-converter/get-transactions-from-glacier';
+import { getTransactionsFromHyperEvm } from './converters/hyperevm-transaction-converter/get-transactions-from-hyperevm';
 import type { EvmGlacierService } from '../../services/glacier-service/glacier-service';
+import type { HyperEvmEtherscanClient } from '../../services/hyperevm-etherscan-client/hyperevm-etherscan-client';
 
 jest.mock('./converters/evm-transaction-converter/get-transactions-from-glacier', () => ({
   getTransactionsFromGlacier: jest.fn(),
@@ -11,7 +13,29 @@ jest.mock('./converters/moralis-transaction-converter/get-transactions-from-mora
   getTransactionsFromMoralis: jest.fn(),
 }));
 
+jest.mock('./converters/hyperevm-transaction-converter/get-transactions-from-hyperevm', () => ({
+  getTransactionsFromHyperEvm: jest.fn(),
+}));
+
 describe('get-transaction-history', () => {
+  it('routes HyperEVM (999) to its explorer before the Glacier fallback', async () => {
+    await getTransactionHistory({
+      glacierService: {} as EvmGlacierService,
+      hyperEvmEtherscanClient: {} as HyperEvmEtherscanClient,
+      chainId: 999,
+      networkToken: {
+        name: 'Hyperliquid',
+        symbol: 'HYPE',
+        decimals: 18,
+      },
+      explorerUrl: 'https://hyperevmscan.io',
+      address: '0xaddress',
+    });
+
+    expect(getTransactionsFromHyperEvm).toHaveBeenCalled();
+    expect(getTransactionsFromGlacier).not.toHaveBeenCalled();
+  });
+
   it('should have called getTransactionsFromMoralis for Ethereum mainnet (1)', async () => {
     await getTransactionHistory({
       glacierService: {} as EvmGlacierService,

--- a/packages/evm-module/src/handlers/get-transaction-history/get-transaction-history.ts
+++ b/packages/evm-module/src/handlers/get-transaction-history/get-transaction-history.ts
@@ -34,6 +34,7 @@ export const getTransactionHistory = async ({
 
     return getTransactionsFromHyperEvm({
       client: hyperEvmEtherscanClient,
+      chainId,
       networkToken,
       explorerUrl,
       address,

--- a/packages/evm-module/src/handlers/get-transaction-history/get-transaction-history.ts
+++ b/packages/evm-module/src/handlers/get-transaction-history/get-transaction-history.ts
@@ -3,6 +3,10 @@ import { isMoralisSupportedChain } from './utils/moralis-chain-ids';
 import type { NetworkToken, TransactionHistoryResponse } from '@avalabs/vm-module-types';
 import { getTransactionsFromGlacier } from './converters/evm-transaction-converter/get-transactions-from-glacier';
 import type { EvmGlacierService } from '../../services/glacier-service/glacier-service';
+import type { HyperEvmEtherscanClient } from '../../services/hyperevm-etherscan-client/hyperevm-etherscan-client';
+import { getTransactionsFromHyperEvm } from './converters/hyperevm-transaction-converter/get-transactions-from-hyperevm';
+
+const HYPEREVM_CHAIN_ID = 999;
 
 export const getTransactionHistory = async ({
   chainId,
@@ -12,6 +16,7 @@ export const getTransactionHistory = async ({
   nextPageToken,
   offset,
   glacierService,
+  hyperEvmEtherscanClient,
 }: {
   chainId: number;
   networkToken: NetworkToken;
@@ -20,7 +25,23 @@ export const getTransactionHistory = async ({
   nextPageToken?: string;
   offset?: number;
   glacierService: EvmGlacierService;
+  hyperEvmEtherscanClient?: HyperEvmEtherscanClient;
 }): Promise<TransactionHistoryResponse> => {
+  if (chainId === HYPEREVM_CHAIN_ID) {
+    if (!hyperEvmEtherscanClient) {
+      return { transactions: [], nextPageToken: '' };
+    }
+
+    return getTransactionsFromHyperEvm({
+      client: hyperEvmEtherscanClient,
+      networkToken,
+      explorerUrl,
+      address,
+      nextPageToken,
+      offset,
+    });
+  }
+
   if (isMoralisSupportedChain(chainId)) {
     return getTransactionsFromMoralis({
       chainId,

--- a/packages/evm-module/src/module.ts
+++ b/packages/evm-module/src/module.ts
@@ -45,6 +45,7 @@ import { DeBankService } from './services/debank-service/debank-service';
 import { EvmGlacierService } from './services/glacier-service/glacier-service';
 import { getProvider } from './utils/get-provider';
 import { supportsBatchApprovals } from './utils/type-utils';
+import { HyperEvmEtherscanClient } from './services/hyperevm-etherscan-client/hyperevm-etherscan-client';
 
 export class EvmModule implements Module {
   #glacierService: EvmGlacierService;
@@ -53,6 +54,7 @@ export class EvmModule implements Module {
   #approvalController: ApprovalController;
   #blockaid: Blockaid;
   #runtime?: RuntimeParams;
+  #hyperEvmEtherscanClient: HyperEvmEtherscanClient;
 
   constructor({ approvalController, environment, appInfo, runtime }: ConstructorParams) {
     const { glacierApiUrl, proxyApiUrl } = getEnv(environment);
@@ -63,6 +65,10 @@ export class EvmModule implements Module {
     });
     this.#deBankService = new DeBankService({ proxyApiUrl, fetch: this.#runtime?.fetch });
     this.#proxyApiUrl = proxyApiUrl;
+    this.#hyperEvmEtherscanClient = new HyperEvmEtherscanClient({
+      proxyApiUrl,
+      fetch: this.#runtime?.fetch,
+    });
     this.#approvalController = approvalController;
     this.#blockaid = new Blockaid({
       baseURL: proxyApiUrl + '/proxy/blockaid/',
@@ -160,6 +166,7 @@ export class EvmModule implements Module {
       nextPageToken,
       offset,
       glacierService: this.#glacierService,
+      hyperEvmEtherscanClient: this.#hyperEvmEtherscanClient,
     });
   }
 

--- a/packages/evm-module/src/services/hyperevm-etherscan-client/hyperevm-etherscan-client.test.ts
+++ b/packages/evm-module/src/services/hyperevm-etherscan-client/hyperevm-etherscan-client.test.ts
@@ -1,0 +1,74 @@
+import { HyperEvmEtherscanClient } from './hyperevm-etherscan-client';
+
+const normalTransaction = {
+  blockNumber: '1',
+  timeStamp: '1',
+  hash: '0xhash',
+  nonce: '0',
+  blockHash: '0xblock',
+  transactionIndex: '0',
+  from: '0xfrom',
+  to: '0xto',
+  value: '0',
+  gas: '1',
+  gasPrice: '1',
+  isError: '0',
+  txreceipt_status: '1',
+  input: '0x',
+  contractAddress: '',
+  cumulativeGasUsed: '1',
+  gasUsed: '1',
+  confirmations: '1',
+};
+
+describe('HyperEvmEtherscanClient', () => {
+  it('uses the HyperEVM Etherscan proxy with explicit pagination', async () => {
+    const fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        status: '1',
+        message: 'OK',
+        result: [normalTransaction],
+      }),
+    });
+    const client = new HyperEvmEtherscanClient({
+      proxyApiUrl: 'https://proxy.example',
+      fetch,
+    });
+
+    await expect(client.listNormalTransactions('0xaddress', { page: 2, offset: 50 })).resolves.toEqual([
+      normalTransaction,
+    ]);
+    expect(fetch).toHaveBeenCalledWith(
+      'https://proxy.example/proxy/etherscan/hyperevm/api?module=account&action=txlist&address=0xaddress&page=2&offset=50&sort=desc',
+    );
+  });
+
+  it('returns an empty list for the explorer no-transactions response', async () => {
+    const client = new HyperEvmEtherscanClient({
+      proxyApiUrl: 'https://proxy.example',
+      fetch: jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          status: '0',
+          message: 'No transactions found',
+          result: 'No transactions found',
+        }),
+      }),
+    });
+
+    await expect(client.listErc20Transfers('0xaddress')).resolves.toEqual([]);
+  });
+
+  it('rejects malformed explorer responses at the boundary', async () => {
+    const client = new HyperEvmEtherscanClient({
+      proxyApiUrl: 'https://proxy.example',
+      fetch: jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ status: '1', message: 'OK', result: [{ hash: '0x' }] }),
+      }),
+    });
+
+    await expect(client.listInternalTransactions('0xaddress')).rejects.toThrow();
+  });
+});

--- a/packages/evm-module/src/services/hyperevm-etherscan-client/hyperevm-etherscan-client.ts
+++ b/packages/evm-module/src/services/hyperevm-etherscan-client/hyperevm-etherscan-client.ts
@@ -1,0 +1,97 @@
+import { z } from 'zod';
+import {
+  hyperEvmErc20TransferSchema,
+  hyperEvmInternalTransactionSchema,
+  hyperEvmNormalTransactionSchema,
+  type HyperEvmErc20Transfer,
+  type HyperEvmInternalTransaction,
+  type HyperEvmNormalTransaction,
+} from './schemas';
+
+type EtherscanAction = 'txlist' | 'tokentx' | 'txlistinternal';
+
+type EtherscanPageOptions = {
+  page?: number;
+  offset?: number;
+};
+
+export type HyperEvmEtherscanClientConfig = {
+  proxyApiUrl: string;
+  fetch?: typeof globalThis.fetch;
+};
+
+const resolveFetch = (fetchFn?: typeof globalThis.fetch) => {
+  if (fetchFn) {
+    return fetchFn;
+  }
+
+  if (typeof globalThis.fetch === 'function') {
+    return globalThis.fetch.bind(globalThis);
+  }
+
+  throw new Error('HyperEvmEtherscanClient requires a fetch implementation');
+};
+
+export class HyperEvmEtherscanClient {
+  readonly #apiUrl: string;
+  readonly #fetch: typeof globalThis.fetch;
+
+  constructor({ proxyApiUrl, fetch }: HyperEvmEtherscanClientConfig) {
+    this.#apiUrl = `${proxyApiUrl}/proxy/etherscan/hyperevm/api`;
+    this.#fetch = resolveFetch(fetch);
+  }
+
+  listNormalTransactions(address: string, options?: EtherscanPageOptions) {
+    return this.#list('txlist', address, hyperEvmNormalTransactionSchema, options);
+  }
+
+  listErc20Transfers(address: string, options?: EtherscanPageOptions) {
+    return this.#list('tokentx', address, hyperEvmErc20TransferSchema, options);
+  }
+
+  listInternalTransactions(address: string, options?: EtherscanPageOptions) {
+    return this.#list('txlistinternal', address, hyperEvmInternalTransactionSchema, options);
+  }
+
+  async #list<T>(
+    action: EtherscanAction,
+    address: string,
+    schema: z.ZodType<T>,
+    options?: EtherscanPageOptions,
+  ): Promise<T[]> {
+    const params = new URLSearchParams({
+      module: 'account',
+      action,
+      address,
+      page: (options?.page ?? 1).toString(),
+      offset: (options?.offset ?? 25).toString(),
+      sort: 'desc',
+    });
+    const response = await this.#fetch(`${this.#apiUrl}?${params.toString()}`);
+
+    if (!response.ok) {
+      throw new Error(`HyperEVM explorer request failed: ${response.status} ${response.statusText}`);
+    }
+
+    const json: unknown = await response.json();
+    const parsed = z
+      .object({
+        status: z.string(),
+        message: z.string(),
+        result: z.union([z.array(schema), z.string()]),
+      })
+      .parse(json);
+
+    if (Array.isArray(parsed.result)) {
+      return parsed.result;
+    }
+
+    if (parsed.status === '0' && parsed.message === 'No transactions found') {
+      return [];
+    }
+
+    throw new Error(parsed.result);
+  }
+}
+
+export type { HyperEvmErc20Transfer, HyperEvmInternalTransaction, HyperEvmNormalTransaction };

--- a/packages/evm-module/src/services/hyperevm-etherscan-client/schemas.ts
+++ b/packages/evm-module/src/services/hyperevm-etherscan-client/schemas.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+
+export const hyperEvmNormalTransactionSchema = z.object({
+  blockNumber: z.string(),
+  timeStamp: z.string(),
+  hash: z.string(),
+  nonce: z.string(),
+  blockHash: z.string(),
+  transactionIndex: z.string(),
+  from: z.string(),
+  to: z.string(),
+  value: z.string(),
+  gas: z.string(),
+  gasPrice: z.string(),
+  isError: z.string(),
+  txreceipt_status: z.string(),
+  input: z.string(),
+  contractAddress: z.string(),
+  cumulativeGasUsed: z.string(),
+  gasUsed: z.string(),
+  confirmations: z.string(),
+});
+
+export const hyperEvmErc20TransferSchema = z.object({
+  blockNumber: z.string(),
+  timeStamp: z.string(),
+  hash: z.string(),
+  nonce: z.string(),
+  blockHash: z.string(),
+  from: z.string(),
+  contractAddress: z.string(),
+  to: z.string(),
+  value: z.string(),
+  tokenName: z.string(),
+  tokenSymbol: z.string(),
+  tokenDecimal: z.string(),
+  transactionIndex: z.string(),
+  gas: z.string(),
+  gasPrice: z.string(),
+  gasUsed: z.string(),
+  cumulativeGasUsed: z.string(),
+  input: z.string(),
+  confirmations: z.string(),
+});
+
+export const hyperEvmInternalTransactionSchema = z.object({
+  blockNumber: z.string(),
+  timeStamp: z.string(),
+  hash: z.string(),
+  from: z.string(),
+  to: z.string(),
+  value: z.string(),
+  contractAddress: z.string(),
+  input: z.string(),
+  type: z.string(),
+  gas: z.string(),
+  gasUsed: z.string(),
+  traceId: z.string(),
+  isError: z.string(),
+  errCode: z.string(),
+});
+
+export type HyperEvmNormalTransaction = z.infer<typeof hyperEvmNormalTransactionSchema>;
+export type HyperEvmErc20Transfer = z.infer<typeof hyperEvmErc20TransferSchema>;
+export type HyperEvmInternalTransaction = z.infer<typeof hyperEvmInternalTransactionSchema>;


### PR DESCRIPTION
Jira ticket: https://ava-labs.atlassian.net/browse/CP-14789

## Changes

- Adds hyperevm etherscan support to querying transaction history for HL hyperevm
- Required as our Moralis and Glacier service does not index historical txs on hyperevm