### PR TITLE
fix(svm-module): handle failed Blockaid simulation without crashing

### DIFF
--- a/.changeset/cuddly-kiwis-attack.md
+++ b/.changeset/cuddly-kiwis-attack.md
@@ -1,0 +1,11 @@
+---
+'@avalabs/svm-module': patch
+'@avalabs/avalanche-module': patch
+'@avalabs/bitcoin-module': patch
+'@avalabs/evm-module': patch
+'@avalabs/hvm-module': patch
+'@avalabs/hypercore-module': patch
+'@avalabs/vm-module-types': patch
+---
+
+Improved simulation error handling for solana

--- a/.changeset/glacier-shared-util.md
+++ b/.changeset/glacier-shared-util.md
@@ -1,0 +1,6 @@
+---
+'@avalabs/svm-module': patch
+'@avalabs/evm-module': patch
+---
+
+Add Glacier API key to the Solana provider RPC url and share the `addGlacierAPIKeyIfNeeded` helper between the EVM and SVM modules

--- a/packages-internal/utils/src/index.ts
+++ b/packages-internal/utils/src/index.ts
@@ -5,5 +5,6 @@ export { retry, RetryBackoffPolicy } from './utils/retry';
 export { fetchAndVerify } from './utils/fetch-and-verify';
 export { getCoreHeaders } from './utils/get-core-headers';
 export { getGlacierApiKey } from './utils/get-glacier-api-key';
+export { addGlacierAPIKeyIfNeeded } from './utils/add-glacier-api-key-if-needed';
 export { GlacierFetchHttpRequest } from './utils/glacier-fetch-http-request';
 export { rpcErrorOpts } from './utils/rpc-error-opts';

--- a/packages-internal/utils/src/utils/add-glacier-api-key-if-needed.test.ts
+++ b/packages-internal/utils/src/utils/add-glacier-api-key-if-needed.test.ts
@@ -1,0 +1,45 @@
+import { addGlacierAPIKeyIfNeeded } from './add-glacier-api-key-if-needed';
+import { getGlacierApiKey } from './get-glacier-api-key';
+
+jest.mock('./get-glacier-api-key', () => ({
+  getGlacierApiKey: jest.fn(),
+}));
+
+describe('packages-internal/utils/src/utils/add-glacier-api-key-if-needed', () => {
+  beforeEach(() => {
+    jest.mocked(getGlacierApiKey).mockReturnValue(undefined);
+  });
+
+  it('adds the token query param for known hosts when a key is configured', () => {
+    jest.mocked(getGlacierApiKey).mockReturnValue('secret-key');
+
+    expect(addGlacierAPIKeyIfNeeded('https://glacier-api.avax.network/rpc')).toBe(
+      'https://glacier-api.avax.network/rpc?token=secret-key',
+    );
+    expect(addGlacierAPIKeyIfNeeded('https://proxy-api.avax.network/proxy/nownodes/sol')).toBe(
+      'https://proxy-api.avax.network/proxy/nownodes/sol?token=secret-key',
+    );
+  });
+
+  it('preserves existing query params when adding the token', () => {
+    jest.mocked(getGlacierApiKey).mockReturnValue('secret-key');
+
+    expect(addGlacierAPIKeyIfNeeded('https://glacier-api.avax.network/rpc?foo=bar')).toBe(
+      'https://glacier-api.avax.network/rpc?foo=bar&token=secret-key',
+    );
+  });
+
+  it('does not modify the url for unknown hosts', () => {
+    jest.mocked(getGlacierApiKey).mockReturnValue('secret-key');
+
+    const url = 'https://localhost:3000/proxy/nownodes/sol';
+    expect(addGlacierAPIKeyIfNeeded(url)).toBe(url);
+  });
+
+  it('does not modify the url when no key is configured', () => {
+    jest.mocked(getGlacierApiKey).mockReturnValue(undefined);
+
+    const url = 'https://glacier-api.avax.network/rpc';
+    expect(addGlacierAPIKeyIfNeeded(url)).toBe(url);
+  });
+});

--- a/packages-internal/utils/src/utils/add-glacier-api-key-if-needed.ts
+++ b/packages-internal/utils/src/utils/add-glacier-api-key-if-needed.ts
@@ -1,0 +1,20 @@
+import { getGlacierApiKey } from './get-glacier-api-key';
+
+// RPC urls returned in the token list are always using the production URL
+const knownHosts = ['glacier-api.avax.network', 'proxy-api.avax.network'];
+
+/**
+ * Glacier needs an API key for development, this adds the key if needed.
+ */
+export function addGlacierAPIKeyIfNeeded(url: string): string {
+  const urlObj = new URL(url);
+  const glacierApiKey = getGlacierApiKey();
+
+  if (glacierApiKey && knownHosts.includes(urlObj.hostname)) {
+    const search_params = urlObj.searchParams; // copy, does not update the URL
+    search_params.set('token', glacierApiKey);
+    urlObj.search = search_params.toString();
+    return urlObj.toString();
+  }
+  return url;
+}

--- a/packages-internal/utils/src/utils/add-glacier-api-key-if-needed.ts
+++ b/packages-internal/utils/src/utils/add-glacier-api-key-if-needed.ts
@@ -1,7 +1,7 @@
 import { getGlacierApiKey } from './get-glacier-api-key';
 
 // RPC urls returned in the token list are always using the production URL
-const knownHosts = ['glacier-api.avax.network', 'proxy-api.avax.network'];
+const knownHosts = ['glacier-api.avax.network', 'proxy-api.avax.network', 'proxy-api-dev.avax.network'];
 
 /**
  * Glacier needs an API key for development, this adds the key if needed.

--- a/packages/evm-module/src/utils/get-provider.ts
+++ b/packages/evm-module/src/utils/get-provider.ts
@@ -1,5 +1,5 @@
 import { JsonRpcBatchInternal } from '@avalabs/core-wallets-sdk';
-import { getGlacierApiKey } from '@internal/utils';
+import { addGlacierAPIKeyIfNeeded } from '@internal/utils';
 import { FetchRequest, Network as EVMNetwork } from 'ethers';
 
 type ProviderParams = {
@@ -37,22 +37,3 @@ export const getProvider = async (params: ProviderParams): Promise<JsonRpcBatchI
 
   return provider;
 };
-
-// RPC urls returned in the token list are always using the production URL
-const knownHosts = ['glacier-api.avax.network', 'proxy-api.avax.network'];
-
-/**
- * Glacier needs an API key for development, this adds the key if needed.
- */
-export function addGlacierAPIKeyIfNeeded(url: string): string {
-  const urlObj = new URL(url);
-  const glacierApiKey = getGlacierApiKey();
-
-  if (glacierApiKey && knownHosts.includes(urlObj.hostname)) {
-    const search_params = urlObj.searchParams; // copy, does not update the URL
-    search_params.set('token', glacierApiKey);
-    urlObj.search = search_params.toString();
-    return urlObj.toString();
-  }
-  return url;
-}

--- a/packages/svm-module/src/utils/explain/explain-transaction.test.ts
+++ b/packages/svm-module/src/utils/explain/explain-transaction.test.ts
@@ -182,6 +182,66 @@ describe('explainTransaction', () => {
     });
   });
 
+  it('should not crash and surface a revert alert when Blockaid simulation status is Error (insufficient rent)', async () => {
+    // Real Blockaid response shape when the simulation itself errors: `simulation`
+    // is a truthy object WITHOUT `account_summary`, validation is Benign, and the
+    // real reason lives in the top-level error_details.
+    const mockScanResponse = {
+      status: 'ERROR',
+      result: {
+        simulation: {
+          status: 'Error',
+          error: 'Failed to simulate transaction',
+          error_details: null,
+          params: {},
+        },
+        validation: {
+          result_type: 'Benign',
+          reason: 'There was an error validating the transaction',
+          features: [],
+          extended_features: [],
+        },
+        gas_estimation: null,
+        slot: null,
+      },
+      error: 'The transaction was reverted',
+      error_details: {
+        type: 'TransactionError',
+        message: 'Account GVV1dfBGtdfCk2hdSdm74S9yE1gg3T5Hc39w5RwsSiSV has insufficient funds for rent',
+        transaction_index: 0,
+      },
+    };
+
+    jest.mocked(scanSolanaTransaction).mockResolvedValueOnce(
+      mockScanResponse as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+    );
+
+    const mockParseTransaction = {
+      balanceChange: { ins: [], outs: [] },
+      details: [{ title: 'Mock section', items: [] }],
+    };
+    jest.mocked(parseTransaction).mockResolvedValueOnce(
+      mockParseTransaction as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+    );
+
+    const result = await explainTransaction({
+      simulationParams: mockSimulationParams,
+      network: mockNetwork,
+      provider: mockProvider,
+    });
+
+    // An errored simulation is not a successful one - fall back to manual parsing.
+    expect(result.isSimulationSuccessful).toBe(false);
+    expect(result.alert).toEqual({
+      type: AlertType.WARNING,
+      details: {
+        title: 'This transaction will likely be reverted',
+        description:
+          'The recipient account needs a minimum balance to exist on Solana (rent). Try increasing the amount you send.',
+      },
+    });
+  });
+
   it('should return parsed transaction details', async () => {
     const mockParseTransaction = {
       balanceChange: {

--- a/packages/svm-module/src/utils/explain/explain-transaction.ts
+++ b/packages/svm-module/src/utils/explain/explain-transaction.ts
@@ -28,7 +28,12 @@ export const explainTransaction = async ({
 }): Promise<TransactionSimulationResult & { details: DetailSection[] }> => {
   const { params } = simulationParams;
   const scanResponse = await scanSolanaTransaction(simulationParams);
-  const { simulation, validation } = scanResponse?.result ?? {};
+  const { simulation: rawSimulation, validation } = scanResponse?.result ?? {};
+  // A failed Blockaid simulation still comes back as a (truthy) object - e.g.
+  // `{ status: 'Error', error, error_details }` - but without an `account_summary`.
+  // Only treat it as a usable simulation when that data is actually present,
+  // otherwise we fall back to manual parsing instead of crashing.
+  const simulation = rawSimulation?.account_summary ? rawSimulation : undefined;
   const genericDetails: DetailSection = {
     title: 'Transaction Details',
     items: [dataItem('Raw Data', simulationParams.params.transactionBase64)],

--- a/packages/svm-module/src/utils/get-provider.test.ts
+++ b/packages/svm-module/src/utils/get-provider.test.ts
@@ -1,9 +1,14 @@
 import { getSolanaProvider } from '@avalabs/core-wallets-sdk';
+import { addGlacierAPIKeyIfNeeded } from '@internal/utils';
 
 import { getProvider } from './get-provider';
 
 jest.mock('@avalabs/core-wallets-sdk', () => ({
   getSolanaProvider: jest.fn(),
+}));
+
+jest.mock('@internal/utils', () => ({
+  addGlacierAPIKeyIfNeeded: jest.fn((url: string) => url),
 }));
 
 const proxyApiUrl = 'https://localhost:3000';
@@ -20,6 +25,20 @@ describe('packages/svm-module/src/utils/get-provider', () => {
     expect(getSolanaProvider).toHaveBeenCalledWith({
       isTestnet: true,
       rpcUrl: 'https://api.devnet.solana.com',
+    });
+  });
+
+  it('should add the glacier API key to the rpc url', () => {
+    jest
+      .mocked(addGlacierAPIKeyIfNeeded)
+      .mockReturnValue('https://proxy-api.avax.network/proxy/nownodes/sol?token=secret-key');
+
+    getProvider({ proxyApiUrl: 'https://proxy-api.avax.network', isTestnet: false });
+
+    expect(addGlacierAPIKeyIfNeeded).toHaveBeenCalledWith('https://proxy-api.avax.network/proxy/nownodes/sol');
+    expect(getSolanaProvider).toHaveBeenCalledWith({
+      isTestnet: false,
+      rpcUrl: 'https://proxy-api.avax.network/proxy/nownodes/sol?token=secret-key',
     });
   });
 });

--- a/packages/svm-module/src/utils/get-provider.ts
+++ b/packages/svm-module/src/utils/get-provider.ts
@@ -1,4 +1,5 @@
 import { getSolanaProvider, type SolanaProvider } from '@avalabs/core-wallets-sdk';
+import { addGlacierAPIKeyIfNeeded } from '@internal/utils';
 
 import { RPC_URL_DEVNET, RPC_URL_PROXY_API_ENDPOINT } from '../constants';
 
@@ -9,8 +10,10 @@ export const getProvider = ({
   isTestnet: boolean;
   proxyApiUrl: string;
 }): SolanaProvider => {
+  const rpcUrl = isTestnet ? RPC_URL_DEVNET : proxyApiUrl + RPC_URL_PROXY_API_ENDPOINT;
+
   return getSolanaProvider({
     isTestnet,
-    rpcUrl: isTestnet ? RPC_URL_DEVNET : proxyApiUrl + RPC_URL_PROXY_API_ENDPOINT,
+    rpcUrl: addGlacierAPIKeyIfNeeded(rpcUrl),
   });
 };

--- a/packages/svm-module/src/utils/get-provider.ts
+++ b/packages/svm-module/src/utils/get-provider.ts
@@ -12,8 +12,6 @@ export const getProvider = ({
 }): SolanaProvider => {
   const rpcUrl = isTestnet ? RPC_URL_DEVNET : proxyApiUrl + RPC_URL_PROXY_API_ENDPOINT;
   const url = addGlacierAPIKeyIfNeeded(rpcUrl);
-  // eslint-disable-next-line no-console
-  console.log('url', url);
   return getSolanaProvider({
     isTestnet,
     rpcUrl: url,

--- a/packages/svm-module/src/utils/get-provider.ts
+++ b/packages/svm-module/src/utils/get-provider.ts
@@ -11,9 +11,10 @@ export const getProvider = ({
   proxyApiUrl: string;
 }): SolanaProvider => {
   const rpcUrl = isTestnet ? RPC_URL_DEVNET : proxyApiUrl + RPC_URL_PROXY_API_ENDPOINT;
-
+  const url = addGlacierAPIKeyIfNeeded(rpcUrl);
+  console.log('url', url);
   return getSolanaProvider({
     isTestnet,
-    rpcUrl: addGlacierAPIKeyIfNeeded(rpcUrl),
+    rpcUrl: url,
   });
 };

--- a/packages/svm-module/src/utils/get-provider.ts
+++ b/packages/svm-module/src/utils/get-provider.ts
@@ -12,6 +12,7 @@ export const getProvider = ({
 }): SolanaProvider => {
   const rpcUrl = isTestnet ? RPC_URL_DEVNET : proxyApiUrl + RPC_URL_PROXY_API_ENDPOINT;
   const url = addGlacierAPIKeyIfNeeded(rpcUrl);
+  // eslint-disable-next-line no-console
   console.log('url', url);
   return getSolanaProvider({
     isTestnet,

--- a/packages/svm-module/src/utils/transaction-alerts.ts
+++ b/packages/svm-module/src/utils/transaction-alerts.ts
@@ -15,6 +15,17 @@ export const getAlertForError = (error: MessageScanResponse['error_details']): A
     }
   }
 
+  if (error?.type === 'TransactionError' && error.message.toLowerCase().includes('insufficient funds for rent')) {
+    return {
+      type: AlertType.WARNING,
+      details: {
+        title: 'This transaction will likely be reverted',
+        description:
+          'The recipient account needs a minimum balance to exist on Solana (rent). Try increasing the amount you send.',
+      },
+    };
+  }
+
   return {
     type: AlertType.WARNING,
     details: {


### PR DESCRIPTION
## Problem
Sending a SOL transfer below the rent-exempt minimum to an empty account causes the SVM module to crash with:

```
Cannot read properties of undefined (reading 'account_assets_diff')
```

Blockaid's `message.scan` returns a `simulation` object with `status: 'Error'` and **no `account_summary`** when the simulation itself fails. The Blockaid types only model `simulation: Result.Simulation | null`, so `explainTransaction` treated the (truthy) error object as a successful simulation and `processBalanceChange` dereferenced `simulationResult.account_summary.account_assets_diff`. The real failure reason (`insufficient funds for rent`) was also swallowed.

## Fix
- **`explain-transaction.ts`** — only use `simulation` when it actually has an `account_summary`; otherwise fall back to manual transaction parsing (`isSimulationSuccessful: false`) instead of crashing.
- **`transaction-alerts.ts`** — `getAlertForError` now recognises the `TransactionError` "insufficient funds for rent" case and returns an actionable alert instead of a generic/misleading one.

## Test plan
- Added a test reproducing the real Blockaid error response (errored simulation + `TransactionError` rent error). It failed with the exact production `account_assets_diff` TypeError before the fix and passes after.
- Full `svm-module` suite: 79 tests pass. (`module.test.ts` fails to load due to a pre-existing missing `@avalabs/crypto-sdk` dependency, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)