### PR TITLE
feat!: route Glacier calls through core-proxy-api and require per-request auth headers (CP-14847)

### DIFF
--- a/.changeset/glacier-core-proxy-appcheck.md
+++ b/.changeset/glacier-core-proxy-appcheck.md
@@ -1,0 +1,12 @@
+---
+'@avalabs/vm-module-types': minor
+'@avalabs/evm-module': minor
+'@avalabs/avalanche-module': minor
+'@avalabs/bitcoin-module': minor
+---
+
+Route Glacier calls through core-proxy-api and support per-request auth headers.
+
+- `glacierApiUrl` now points at `core-proxy-api.avax.network/v1/proxy/glacier` (prod) / `core-proxy-api.avax-test.network/v1/proxy/glacier` (dev). The old `glacier-api.avax.network` host is losing its EVM endpoints as part of the Glacier migration.
+- New `RuntimeParams.getAuthHeaders` lets consumers attach auth headers (e.g. a Firebase AppCheck token, required by core-proxy-api) to every internal Glacier request — resolved per request so short-lived tokens stay fresh.
+- Removed the unused `glacierApiUrl` from bitcoin-module's env (bitcoin traffic goes through the proxy-api worker, which is unchanged).

--- a/.changeset/glacier-core-proxy-appcheck.md
+++ b/.changeset/glacier-core-proxy-appcheck.md
@@ -1,12 +1,12 @@
 ---
-'@avalabs/vm-module-types': minor
-'@avalabs/evm-module': minor
-'@avalabs/avalanche-module': minor
-'@avalabs/bitcoin-module': minor
+'@avalabs/vm-module-types': major
+'@avalabs/evm-module': major
+'@avalabs/avalanche-module': major
+'@avalabs/bitcoin-module': major
 ---
 
-Route Glacier calls through core-proxy-api and support per-request auth headers.
+Route Glacier calls through core-proxy-api and require per-request auth headers on the EVM and Avalanche modules.
 
-- `glacierApiUrl` now points at `core-proxy-api.avax.network/v1/proxy/glacier` (prod) / `core-proxy-api.avax-test.network/v1/proxy/glacier` (dev). The old `glacier-api.avax.network` host is losing its EVM endpoints as part of the Glacier migration.
-- New `RuntimeParams.getAuthHeaders` lets consumers attach auth headers (e.g. a Firebase AppCheck token, required by core-proxy-api) to every internal Glacier request — resolved per request so short-lived tokens stay fresh.
-- Removed the unused `glacierApiUrl` from bitcoin-module's env (bitcoin traffic goes through the proxy-api worker, which is unchanged).
+BREAKING: `EvmModule` and `AvalancheModule` now require `runtime.getAuthHeaders` in their constructor params — an async resolver for auth headers (e.g. a Firebase AppCheck token) invoked on every internal Glacier request. Without it those modules cannot function: `glacierApiUrl` now points at `core-proxy-api.avax.network/v1/proxy/glacier` (prod) / `core-proxy-api.avax-test.network/v1/proxy/glacier` (dev), which rejects unauthenticated requests, and the old `glacier-api.avax.network` host is losing its EVM endpoints as part of the Glacier migration.
+
+Also removed the unused `glacierApiUrl` from bitcoin-module's env (bitcoin traffic goes through the proxy-api worker, which is unchanged).

--- a/.changeset/glacier-core-proxy-appcheck.md
+++ b/.changeset/glacier-core-proxy-appcheck.md
@@ -3,10 +3,13 @@
 '@avalabs/evm-module': major
 '@avalabs/avalanche-module': major
 '@avalabs/bitcoin-module': major
+'@avalabs/hvm-module': major
+'@avalabs/hypercore-module': major
+'@avalabs/svm-module': major
 ---
 
 Route Glacier calls through core-proxy-api and require per-request auth headers on the EVM and Avalanche modules.
 
-BREAKING: `EvmModule` and `AvalancheModule` now require `runtime.getAuthHeaders` in their constructor params — an async resolver for auth headers (e.g. a Firebase AppCheck token) invoked on every internal Glacier request. Without it those modules cannot function: `glacierApiUrl` now points at `core-proxy-api.avax.network/v1/proxy/glacier` (prod) / `core-proxy-api.avax-test.network/v1/proxy/glacier` (dev), which rejects unauthenticated requests, and the old `glacier-api.avax.network` host is losing its EVM endpoints as part of the Glacier migration.
+BREAKING: `EvmModule` and `AvalancheModule` now require `runtime.getAuthHeaders` in their constructor params — an async resolver for auth headers (e.g. a Firebase AppCheck token or a Core API key) invoked on every internal Glacier request. Without it those modules cannot function: `glacierApiUrl` now points at `core-proxy-api.avax.network/v1/proxy/glacier` (prod) / `core-proxy-api.avax-test.network/v1/proxy/glacier` (dev), which rejects unauthenticated requests, and the old `glacier-api.avax.network` host is losing its EVM endpoints as part of the Glacier migration.
 
-Also removed the unused `glacierApiUrl` from bitcoin-module's env (bitcoin traffic goes through the proxy-api worker, which is unchanged).
+Also removed the client-side Glacier rate-limit key from the avalanche tx handlers (the proxy injects its own rate-limit bypass upstream; dev builds can supply a Core API key via `getAuthHeaders`) and the unused `glacierApiUrl` from bitcoin-module's env.

--- a/packages-internal/utils/src/utils/add-glacier-api-key-if-needed.test.ts
+++ b/packages-internal/utils/src/utils/add-glacier-api-key-if-needed.test.ts
@@ -19,6 +19,12 @@ describe('packages-internal/utils/src/utils/add-glacier-api-key-if-needed', () =
     expect(addGlacierAPIKeyIfNeeded('https://proxy-api.avax.network/proxy/nownodes/sol')).toBe(
       'https://proxy-api.avax.network/proxy/nownodes/sol?token=secret-key',
     );
+    expect(addGlacierAPIKeyIfNeeded('https://core-proxy-api.avax.network/v1/proxy/glacier/v1/chains')).toBe(
+      'https://core-proxy-api.avax.network/v1/proxy/glacier/v1/chains?token=secret-key',
+    );
+    expect(addGlacierAPIKeyIfNeeded('https://core-proxy-api.avax-test.network/v1/proxy/glacier/v1/chains')).toBe(
+      'https://core-proxy-api.avax-test.network/v1/proxy/glacier/v1/chains?token=secret-key',
+    );
   });
 
   it('preserves existing query params when adding the token', () => {

--- a/packages-internal/utils/src/utils/add-glacier-api-key-if-needed.ts
+++ b/packages-internal/utils/src/utils/add-glacier-api-key-if-needed.ts
@@ -1,7 +1,13 @@
 import { getGlacierApiKey } from './get-glacier-api-key';
 
 // RPC urls returned in the token list are always using the production URL
-const knownHosts = ['glacier-api.avax.network', 'proxy-api.avax.network', 'proxy-api-dev.avax.network'];
+const knownHosts = [
+  'glacier-api.avax.network',
+  'proxy-api.avax.network',
+  'proxy-api-dev.avax.network',
+  'core-proxy-api.avax.network',
+  'core-proxy-api.avax-test.network',
+];
 
 /**
  * Glacier needs an API key for development, this adds the key if needed.

--- a/packages/avalanche-module/src/env.ts
+++ b/packages/avalanche-module/src/env.ts
@@ -6,12 +6,12 @@ type Env = {
 };
 
 export const prodEnv: Env = {
-  glacierApiUrl: 'https://glacier-api.avax.network',
+  glacierApiUrl: 'https://core-proxy-api.avax.network/v1/proxy/glacier',
   proxyApiUrl: 'https://proxy-api.avax.network',
 };
 
 export const devEnv: Env = {
-  glacierApiUrl: 'https://glacier-api-dev.avax.network',
+  glacierApiUrl: 'https://core-proxy-api.avax-test.network/v1/proxy/glacier',
   proxyApiUrl: 'https://proxy-api-dev.avax.network',
 };
 

--- a/packages/avalanche-module/src/handlers/avalanche-send-transaction/avalanche-send-transaction.test.ts
+++ b/packages/avalanche-module/src/handlers/avalanche-send-transaction/avalanche-send-transaction.test.ts
@@ -452,6 +452,36 @@ describe('avalanche_sendTransaction handler', () => {
     });
   });
 
+  it('merges resolved auth headers into the Glacier UTXO request', async () => {
+    mockGetGlacierApiKey.mockReturnValue(undefined);
+    const params = {
+      ...testParams(testRequestParams),
+      getAuthHeaders: jest.fn().mockResolvedValue({ 'X-Firebase-AppCheck': 'appcheck-token' }),
+    };
+    const tx = { vm: AVM };
+
+    (utils.unpackWithManager as jest.Mock).mockReturnValueOnce(tx);
+    (Avalanche.parseAvalancheTx as jest.Mock).mockReturnValueOnce({
+      type: 'import',
+    });
+    (utils.parse as jest.Mock).mockReturnValueOnce([undefined, undefined, new Uint8Array([0, 1, 2])]);
+
+    await avalancheSendTransaction(params);
+
+    expect(Avalanche.getUtxosByTxFromGlacier).toHaveBeenCalledWith({
+      transactionHex: '0x00001',
+      chainAlias: 'X',
+      network: 'fuji',
+      url: GLACIER_API_URL,
+      token: undefined,
+      headers: {
+        'x-application-name': 'core-mobile-ios',
+        'x-application-version': 'version',
+        'X-Firebase-AppCheck': 'appcheck-token',
+      },
+    });
+  });
+
   describe('approve succeeds', () => {
     beforeEach(() => {
       jest.clearAllMocks();

--- a/packages/avalanche-module/src/handlers/avalanche-send-transaction/avalanche-send-transaction.test.ts
+++ b/packages/avalanche-module/src/handlers/avalanche-send-transaction/avalanche-send-transaction.test.ts
@@ -6,7 +6,6 @@ import { Avalanche } from '@avalabs/core-wallets-sdk';
 import { getAddressesByIndices } from './utils/get-addresses-by-indices';
 import { getProvider } from '../../utils/get-provider';
 import { retry } from '@internal/utils/src/utils/retry';
-import { getGlacierApiKey } from '@internal/utils/src/utils/get-glacier-api-key';
 
 const GLACIER_API_URL = 'https://glacier-api.avax.network';
 
@@ -17,11 +16,6 @@ jest.mock('../../utils/get-provider');
 jest.mock('@internal/utils/src/utils/retry', () => ({
   retry: jest.fn(),
 }));
-jest.mock('@internal/utils/src/utils/get-glacier-api-key', () => ({
-  getGlacierApiKey: jest.fn(),
-}));
-
-const mockGetGlacierApiKey = getGlacierApiKey as jest.MockedFunction<typeof getGlacierApiKey>;
 
 const utxosMock = [{ utxoId: '1' }, { utxoId: '2' }];
 
@@ -236,7 +230,6 @@ describe('avalanche_sendTransaction handler', () => {
       chainAlias: 'X',
       network: 'fuji',
       url: GLACIER_API_URL,
-      token: undefined,
       headers: {
         'x-application-name': 'core-mobile-ios',
         'x-application-version': 'version',
@@ -390,7 +383,6 @@ describe('avalanche_sendTransaction handler', () => {
       chainAlias: chainAlias,
       network: 'fuji',
       url: GLACIER_API_URL,
-      token: undefined,
       headers: {
         'x-application-name': 'core-mobile-ios',
         'x-application-version': 'version',
@@ -405,55 +397,7 @@ describe('avalanche_sendTransaction handler', () => {
     });
   });
 
-  it('passes the Glacier API key as token and x-api-key header when it is defined', async () => {
-    mockGetGlacierApiKey.mockReturnValue('test-api-key');
-    const params = testParams(testRequestParams);
-
-    (utils.unpackWithManager as jest.Mock).mockReturnValueOnce({ vm: AVM });
-    (Avalanche.parseAvalancheTx as jest.Mock).mockReturnValueOnce({ type: 'import' });
-    (utils.parse as jest.Mock).mockReturnValueOnce([undefined, undefined, new Uint8Array([0, 1, 2])]);
-
-    await avalancheSendTransaction(params);
-
-    expect(Avalanche.getUtxosByTxFromGlacier).toHaveBeenCalledWith({
-      transactionHex: '0x00001',
-      chainAlias: 'X',
-      network: 'fuji',
-      url: GLACIER_API_URL,
-      token: 'test-api-key',
-      headers: {
-        'x-application-name': 'core-mobile-ios',
-        'x-application-version': 'version',
-        'x-api-key': 'test-api-key',
-      },
-    });
-  });
-
-  it('omits the x-api-key header when the Glacier API key is not defined', async () => {
-    mockGetGlacierApiKey.mockReturnValue(undefined);
-    const params = testParams(testRequestParams);
-
-    (utils.unpackWithManager as jest.Mock).mockReturnValueOnce({ vm: AVM });
-    (Avalanche.parseAvalancheTx as jest.Mock).mockReturnValueOnce({ type: 'import' });
-    (utils.parse as jest.Mock).mockReturnValueOnce([undefined, undefined, new Uint8Array([0, 1, 2])]);
-
-    await avalancheSendTransaction(params);
-
-    expect(Avalanche.getUtxosByTxFromGlacier).toHaveBeenCalledWith({
-      transactionHex: '0x00001',
-      chainAlias: 'X',
-      network: 'fuji',
-      url: GLACIER_API_URL,
-      token: undefined,
-      headers: {
-        'x-application-name': 'core-mobile-ios',
-        'x-application-version': 'version',
-      },
-    });
-  });
-
   it('merges resolved auth headers into the Glacier UTXO request', async () => {
-    mockGetGlacierApiKey.mockReturnValue(undefined);
     const params = {
       ...testParams(testRequestParams),
       getAuthHeaders: jest.fn().mockResolvedValue({ 'X-Firebase-AppCheck': 'appcheck-token' }),
@@ -473,7 +417,6 @@ describe('avalanche_sendTransaction handler', () => {
       chainAlias: 'X',
       network: 'fuji',
       url: GLACIER_API_URL,
-      token: undefined,
       headers: {
         'x-application-name': 'core-mobile-ios',
         'x-application-version': 'version',

--- a/packages/avalanche-module/src/handlers/avalanche-send-transaction/avalanche-send-transaction.ts
+++ b/packages/avalanche-module/src/handlers/avalanche-send-transaction/avalanche-send-transaction.ts
@@ -30,12 +30,14 @@ export const avalancheSendTransaction = async ({
   approvalController,
   glacierApiUrl,
   appInfo,
+  getAuthHeaders,
 }: {
   request: RpcRequest;
   network: Network;
   approvalController: ApprovalController;
   glacierApiUrl: string;
   appInfo: AppInfo;
+  getAuthHeaders?: () => Promise<Record<string, string>>;
 }) => {
   const result = parseRequestParams(request.params);
 
@@ -80,6 +82,7 @@ export const avalancheSendTransaction = async ({
           headers: {
             ...getCoreHeaders(appInfo),
             ...(glacierApiKey ? { 'x-api-key': glacierApiKey } : {}),
+            ...(await getAuthHeaders?.()),
           },
         });
 

--- a/packages/avalanche-module/src/handlers/avalanche-send-transaction/avalanche-send-transaction.ts
+++ b/packages/avalanche-module/src/handlers/avalanche-send-transaction/avalanche-send-transaction.ts
@@ -18,7 +18,7 @@ import { getProvider } from '../../utils/get-provider';
 import { getProvidedUtxos } from '../../utils/get-provided-utxos';
 import { parseTxDetails } from '../../utils/parse-tx-details';
 import { parseTxDisplayTitle } from './utils/parse-tx-display-title';
-import { getCoreHeaders, getGlacierApiKey, retry, rpcErrorOpts } from '@internal/utils';
+import { getCoreHeaders, retry, rpcErrorOpts } from '@internal/utils';
 import { getAddressesByIndices } from './utils/get-addresses-by-indices';
 import { getTransactionDetailSections } from '../../utils/get-transaction-detail-sections';
 import { getExplorerAddressByNetwork } from '../get-transaction-history/utils';
@@ -68,7 +68,6 @@ export const avalancheSendTransaction = async ({
       vm,
     });
 
-    const glacierApiKey = getGlacierApiKey();
     const utxos = providedUtxos.length
       ? providedUtxos
       : await Avalanche.getUtxosByTxFromGlacier({
@@ -76,14 +75,7 @@ export const avalancheSendTransaction = async ({
           chainAlias,
           network: isTestnet ? GlacierNetwork.FUJI : GlacierNetwork.MAINNET,
           url: glacierApiUrl,
-          // This token does not work.
-          // The Glacier SDK sets the token as an Authorization header, however the rate limit token has to be used as a query parameter or as an `x-api-key` header.
-          token: glacierApiKey,
-          headers: {
-            ...getCoreHeaders(appInfo),
-            ...(glacierApiKey ? { 'x-api-key': glacierApiKey } : {}),
-            ...(await getAuthHeaders?.()),
-          },
+          headers: { ...getCoreHeaders(appInfo), ...(await getAuthHeaders?.()) },
         });
 
     let unsignedTx: UnsignedTx | EVMUnsignedTx;

--- a/packages/avalanche-module/src/handlers/avalanche-sign-transaction/avalanche-sign-transaction.test.ts
+++ b/packages/avalanche-module/src/handlers/avalanche-sign-transaction/avalanche-sign-transaction.test.ts
@@ -126,6 +126,28 @@ describe('avalanche-sign-transaction', () => {
     });
   });
 
+  it('merges resolved auth headers into the Glacier UTXO request', async () => {
+    const request = createRequest({ transactionHex: '0x00001', chainAlias: 'P' });
+    mockRequestApproval.mockResolvedValue({ signedData: 'signedData' });
+
+    await avalancheSignTransaction({
+      ...avalancheSignTransactionParams,
+      request,
+      getAuthHeaders: jest.fn().mockResolvedValue({ 'X-Firebase-AppCheck': 'appcheck-token' }),
+    });
+
+    expect(Avalanche.getUtxosByTxFromGlacier).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'glacierApiUrl',
+        headers: {
+          'x-application-name': 'core-mobile-ios',
+          'x-application-version': 'version',
+          'X-Firebase-AppCheck': 'appcheck-token',
+        },
+      }),
+    );
+  });
+
   it('returns error if missing signer address', async () => {
     const request = createRequest({ transactionHex: '0x00001', chainAlias: 'P', from: '123' });
     (utils.addressesFromBytes as jest.Mock).mockReturnValue([]);

--- a/packages/avalanche-module/src/handlers/avalanche-sign-transaction/avalanche-sign-transaction.test.ts
+++ b/packages/avalanche-module/src/handlers/avalanche-sign-transaction/avalanche-sign-transaction.test.ts
@@ -5,15 +5,9 @@ import { avalancheSignTransaction } from './avalanche-sign-transaction';
 import { rpcErrors } from '@metamask/rpc-errors';
 import { Network as GlacierNetwork } from '@avalabs/glacier-sdk';
 import type { GetUpgradesInfoResponse } from '@avalabs/avalanchejs/dist/info/model';
-import { getGlacierApiKey } from '@internal/utils/src/utils/get-glacier-api-key';
 
 jest.mock('@avalabs/avalanchejs');
 jest.mock('@avalabs/core-wallets-sdk');
-jest.mock('@internal/utils/src/utils/get-glacier-api-key', () => ({
-  getGlacierApiKey: jest.fn(),
-}));
-
-const mockGetGlacierApiKey = getGlacierApiKey as jest.MockedFunction<typeof getGlacierApiKey>;
 
 const mockRequestApproval = jest.fn().mockImplementation(() => ({ success: true }));
 const mockApprovalController = {
@@ -256,8 +250,7 @@ describe('avalanche-sign-transaction', () => {
     });
   });
 
-  it('passes the Glacier API key as token and x-api-key header when it is defined', async () => {
-    mockGetGlacierApiKey.mockReturnValue('test-api-key');
+  it('sends only the core headers when no auth header resolver is given', async () => {
     const request = createRequest({ transactionHex: '0x00001', chainAlias: 'P', from: '123' });
     mockRequestApproval.mockResolvedValue({ signedData: 'signedData' });
 
@@ -271,31 +264,6 @@ describe('avalanche-sign-transaction', () => {
       chainAlias: 'P',
       network: GlacierNetwork.MAINNET,
       url: 'glacierApiUrl',
-      token: 'test-api-key',
-      headers: {
-        'x-application-name': 'core-mobile-ios',
-        'x-application-version': 'version',
-        'x-api-key': 'test-api-key',
-      },
-    });
-  });
-
-  it('omits the x-api-key header when the Glacier API key is not defined', async () => {
-    mockGetGlacierApiKey.mockReturnValue(undefined);
-    const request = createRequest({ transactionHex: '0x00001', chainAlias: 'P', from: '123' });
-    mockRequestApproval.mockResolvedValue({ signedData: 'signedData' });
-
-    await avalancheSignTransaction({
-      ...avalancheSignTransactionParams,
-      request,
-    });
-
-    expect(Avalanche.getUtxosByTxFromGlacier).toHaveBeenCalledWith({
-      transactionHex: '0x00001',
-      chainAlias: 'P',
-      network: GlacierNetwork.MAINNET,
-      url: 'glacierApiUrl',
-      token: undefined,
       headers: {
         'x-application-name': 'core-mobile-ios',
         'x-application-version': 'version',

--- a/packages/avalanche-module/src/handlers/avalanche-sign-transaction/avalanche-sign-transaction.ts
+++ b/packages/avalanche-module/src/handlers/avalanche-sign-transaction/avalanche-sign-transaction.ts
@@ -29,12 +29,14 @@ export const avalancheSignTransaction = async ({
   approvalController,
   glacierApiUrl,
   appInfo,
+  getAuthHeaders,
 }: {
   request: RpcRequest;
   network: Network;
   approvalController: ApprovalController;
   glacierApiUrl: string;
   appInfo: AppInfo;
+  getAuthHeaders?: () => Promise<Record<string, string>>;
 }) => {
   const result = parseRequestParams(request.params);
 
@@ -80,6 +82,7 @@ export const avalancheSignTransaction = async ({
         headers: {
           ...getCoreHeaders(appInfo),
           ...(glacierApiKey ? { 'x-api-key': glacierApiKey } : {}),
+          ...(await getAuthHeaders?.()),
         },
       });
 

--- a/packages/avalanche-module/src/handlers/avalanche-sign-transaction/avalanche-sign-transaction.ts
+++ b/packages/avalanche-module/src/handlers/avalanche-sign-transaction/avalanche-sign-transaction.ts
@@ -12,7 +12,7 @@ import { rpcErrors } from '@metamask/rpc-errors';
 import { Avalanche } from '@avalabs/core-wallets-sdk';
 import { Network as GlacierNetwork } from '@avalabs/glacier-sdk';
 
-import { getCoreHeaders, getGlacierApiKey } from '@internal/utils';
+import { getCoreHeaders } from '@internal/utils';
 
 import { getProvider } from '../../utils/get-provider';
 import { parseTxDetails } from '../../utils/parse-tx-details';
@@ -68,7 +68,6 @@ export const avalancheSignTransaction = async ({
     vm,
   });
 
-  const glacierApiKey = getGlacierApiKey();
   const utxos = providedUtxos.length
     ? providedUtxos
     : await Avalanche.getUtxosByTxFromGlacier({
@@ -76,14 +75,7 @@ export const avalancheSignTransaction = async ({
         chainAlias,
         network: isTestnet ? GlacierNetwork.FUJI : GlacierNetwork.MAINNET,
         url: glacierApiUrl,
-        // This token does not work.
-        // The Glacier SDK sets the token as an Authorization header, however the rate limit token has to be used as a query parameter or as an `x-api-key` header.
-        token: glacierApiKey,
-        headers: {
-          ...getCoreHeaders(appInfo),
-          ...(glacierApiKey ? { 'x-api-key': glacierApiKey } : {}),
-          ...(await getAuthHeaders?.()),
-        },
+        headers: { ...getCoreHeaders(appInfo), ...(await getAuthHeaders?.()) },
       });
 
   const unsignedOrPartiallySignedTx = await getUnsignedOrPartiallySignedTx({

--- a/packages/avalanche-module/src/module.ts
+++ b/packages/avalanche-module/src/module.ts
@@ -54,6 +54,9 @@ export class AvalancheModule implements Module {
     this.#glacierService = new AvalancheGlacierService({
       glacierApiUrl,
       headers: getCoreHeaders(appInfo),
+      // Reads #runtime at call time; resolves to no extra headers when
+      // runtime.getAuthHeaders is unset.
+      getAuthHeaders: async () => this.#runtime?.getAuthHeaders?.(),
     });
     this.#proxyApiUrl = proxyApiUrl;
     this.#glacierApiUrl = glacierApiUrl;
@@ -124,6 +127,7 @@ export class AvalancheModule implements Module {
           approvalController: this.#approvalController,
           glacierApiUrl: this.#glacierApiUrl,
           appInfo: this.#appInfo,
+          getAuthHeaders: this.#runtime?.getAuthHeaders,
         });
       case RpcMethod.AVALANCHE_SEND_TRANSACTION:
         return avalancheSendTransaction({
@@ -132,6 +136,7 @@ export class AvalancheModule implements Module {
           approvalController: this.#approvalController,
           glacierApiUrl: this.#glacierApiUrl,
           appInfo: this.#appInfo,
+          getAuthHeaders: this.#runtime?.getAuthHeaders,
         });
       default:
         return { error: rpcErrors.methodNotSupported(`Method ${request.method} not supported`) };

--- a/packages/avalanche-module/src/module.ts
+++ b/packages/avalanche-module/src/module.ts
@@ -39,6 +39,16 @@ import { AvalancheGlacierService } from './services/glacier-service/glacier-serv
 import { getProvider } from './utils/get-provider';
 import { hashBlockchainId } from './utils/hash-blockchain-id';
 
+type AvalancheConstructorParams = Omit<ConstructorParams, 'runtime'> & {
+  /**
+   * Required: the module cannot function without it — P/X/C balances,
+   * transaction history and the UTXO fetch during avalanche_sign/sendTransaction
+   * all go through core-proxy-api, which rejects requests without auth headers
+   * (Firebase AppCheck) — so `getAuthHeaders` must be supplied.
+   */
+  runtime: RuntimeParams & Required<Pick<RuntimeParams, 'getAuthHeaders'>>;
+};
+
 export class AvalancheModule implements Module {
   #glacierService: AvalancheGlacierService;
   #proxyApiUrl: string;
@@ -47,15 +57,14 @@ export class AvalancheModule implements Module {
   #appInfo: AppInfo;
   #runtime?: RuntimeParams;
 
-  constructor({ approvalController, environment, appInfo, runtime }: ConstructorParams) {
+  constructor({ approvalController, environment, appInfo, runtime }: AvalancheConstructorParams) {
     const { glacierApiUrl, proxyApiUrl } = getEnv(environment);
     this.#appInfo = appInfo;
     this.#runtime = runtime;
     this.#glacierService = new AvalancheGlacierService({
       glacierApiUrl,
       headers: getCoreHeaders(appInfo),
-      // Reads #runtime at call time; resolves to no extra headers when
-      // runtime.getAuthHeaders is unset.
+      // Reads #runtime at call time rather than capturing the resolver.
       getAuthHeaders: async () => this.#runtime?.getAuthHeaders?.(),
     });
     this.#proxyApiUrl = proxyApiUrl;

--- a/packages/avalanche-module/src/services/glacier-service/glacier-service.test.ts
+++ b/packages/avalanche-module/src/services/glacier-service/glacier-service.test.ts
@@ -1,0 +1,52 @@
+import { AvalancheGlacierService } from './glacier-service';
+import { Glacier } from '@avalabs/glacier-sdk';
+
+jest.mock('@avalabs/glacier-sdk', () => {
+  const actual = jest.requireActual('@avalabs/glacier-sdk');
+  return {
+    ...actual,
+    Glacier: jest.fn(),
+  };
+});
+
+describe('AvalancheGlacierService', () => {
+  const FAKE_URL = 'http://fake-url';
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('headers config', () => {
+    it('passes static headers straight through when no auth header resolver is given', () => {
+      new AvalancheGlacierService({ glacierApiUrl: FAKE_URL, headers: { 'x-application-name': 'core-mobile-ios' } });
+
+      expect(Glacier).toHaveBeenCalledWith(
+        expect.objectContaining({ BASE: FAKE_URL, HEADERS: { 'x-application-name': 'core-mobile-ios' } }),
+        expect.anything(),
+      );
+    });
+
+    it('resolves auth headers per request, merged over static headers', async () => {
+      const getAuthHeaders = jest.fn().mockResolvedValue({ 'X-Firebase-AppCheck': 'token-1' });
+
+      new AvalancheGlacierService({
+        glacierApiUrl: FAKE_URL,
+        headers: { 'x-application-name': 'core-mobile-ios' },
+        getAuthHeaders,
+      });
+
+      const config = (Glacier as jest.Mock).mock.calls[0]?.[0];
+      expect(typeof config.HEADERS).toBe('function');
+      await expect(config.HEADERS()).resolves.toEqual({
+        'x-application-name': 'core-mobile-ios',
+        'X-Firebase-AppCheck': 'token-1',
+      });
+
+      getAuthHeaders.mockResolvedValue({ 'X-Firebase-AppCheck': 'token-2' });
+      await expect(config.HEADERS()).resolves.toEqual({
+        'x-application-name': 'core-mobile-ios',
+        'X-Firebase-AppCheck': 'token-2',
+      });
+    });
+  });
+});

--- a/packages/avalanche-module/src/services/glacier-service/glacier-service.ts
+++ b/packages/avalanche-module/src/services/glacier-service/glacier-service.ts
@@ -21,8 +21,26 @@ export class AvalancheGlacierService {
   glacierSdk: Glacier;
   isGlacierHealthy = true;
 
-  constructor({ glacierApiUrl, headers }: { glacierApiUrl: string; headers?: Record<string, string> }) {
-    this.glacierSdk = new Glacier({ BASE: glacierApiUrl, HEADERS: headers }, GlacierFetchHttpRequest);
+  constructor({
+    glacierApiUrl,
+    headers,
+    getAuthHeaders,
+  }: {
+    glacierApiUrl: string;
+    headers?: Record<string, string>;
+    /**
+     * Resolves per-request auth headers (e.g. a Firebase AppCheck token) required
+     * by the Glacier proxy. Merged over the static `headers`.
+     */
+    getAuthHeaders?: () => Promise<Record<string, string> | undefined>;
+  }) {
+    this.glacierSdk = new Glacier(
+      {
+        BASE: glacierApiUrl,
+        HEADERS: getAuthHeaders ? async () => ({ ...headers, ...(await getAuthHeaders()) }) : headers,
+      },
+      GlacierFetchHttpRequest,
+    );
   }
 
   isHealthy = (): boolean => this.isGlacierHealthy;

--- a/packages/bitcoin-module/src/env.ts
+++ b/packages/bitcoin-module/src/env.ts
@@ -1,17 +1,14 @@
 import { Environment } from '@avalabs/vm-module-types';
 
 type Env = {
-  glacierApiUrl: string;
   proxyApiUrl: string;
 };
 
 export const prodEnv: Env = {
-  glacierApiUrl: 'https://glacier-api.avax.network',
   proxyApiUrl: 'https://proxy-api.avax.network',
 };
 
 export const devEnv: Env = {
-  glacierApiUrl: 'https://glacier-api-dev.avax.network',
   proxyApiUrl: 'https://proxy-api-dev.avax.network',
 };
 

--- a/packages/evm-module/src/env.ts
+++ b/packages/evm-module/src/env.ts
@@ -6,12 +6,12 @@ type Env = {
 };
 
 export const prodEnv: Env = {
-  glacierApiUrl: 'https://glacier-api.avax.network',
+  glacierApiUrl: 'https://core-proxy-api.avax.network/v1/proxy/glacier',
   proxyApiUrl: 'https://proxy-api.avax.network',
 };
 
 export const devEnv: Env = {
-  glacierApiUrl: 'https://glacier-api-dev.avax.network',
+  glacierApiUrl: 'https://core-proxy-api.avax-test.network/v1/proxy/glacier',
   proxyApiUrl: 'https://proxy-api-dev.avax.network',
 };
 

--- a/packages/evm-module/src/module.ts
+++ b/packages/evm-module/src/module.ts
@@ -58,7 +58,12 @@ type EvmRuntimeParams = RuntimeParams & {
 };
 
 type EvmConstructorParams = Omit<ConstructorParams, 'runtime'> & {
-  runtime?: EvmRuntimeParams;
+  /**
+   * Required: the module's internal Glacier calls (EVM balances, transaction
+   * history) go through core-proxy-api, which rejects requests without auth
+   * headers (Firebase AppCheck) — so `getAuthHeaders` must be supplied.
+   */
+  runtime: EvmRuntimeParams & Required<Pick<RuntimeParams, 'getAuthHeaders'>>;
 };
 
 export class EvmModule implements Module {
@@ -76,9 +81,7 @@ export class EvmModule implements Module {
     this.#glacierService = new EvmGlacierService({
       glacierApiUrl,
       headers: getCoreHeaders(appInfo),
-      // Always a resolver (even when runtime.getAuthHeaders is unset, in which
-      // case it resolves to no extra headers) so that #runtime is read at call
-      // time and updateRuntimeParams() can supply the resolver later.
+      // Reads #runtime at call time so updateRuntimeParams() is respected.
       getAuthHeaders: async () => this.#runtime?.getAuthHeaders?.(),
     });
     this.#deBankService = new DeBankService({ proxyApiUrl, fetch: this.#runtime?.fetch });

--- a/packages/evm-module/src/module.ts
+++ b/packages/evm-module/src/module.ts
@@ -76,6 +76,10 @@ export class EvmModule implements Module {
     this.#glacierService = new EvmGlacierService({
       glacierApiUrl,
       headers: getCoreHeaders(appInfo),
+      // Always a resolver (even when runtime.getAuthHeaders is unset, in which
+      // case it resolves to no extra headers) so that #runtime is read at call
+      // time and updateRuntimeParams() can supply the resolver later.
+      getAuthHeaders: async () => this.#runtime?.getAuthHeaders?.(),
     });
     this.#deBankService = new DeBankService({ proxyApiUrl, fetch: this.#runtime?.fetch });
     this.#proxyApiUrl = proxyApiUrl;

--- a/packages/evm-module/src/services/glacier-service/glacier-service.test.ts
+++ b/packages/evm-module/src/services/glacier-service/glacier-service.test.ts
@@ -32,6 +32,45 @@ describe('GlacierService', () => {
     jest.clearAllMocks();
   });
 
+  describe('headers config', () => {
+    it('passes static headers straight through when no auth header resolver is given', () => {
+      jest.clearAllMocks();
+      (Glacier as jest.Mock).mockReturnValue(mockGlacier);
+
+      new EvmGlacierService({ glacierApiUrl: FAKE_URL, headers: { 'x-application-name': 'core-mobile-ios' } });
+
+      expect(Glacier).toHaveBeenCalledWith(
+        expect.objectContaining({ BASE: FAKE_URL, HEADERS: { 'x-application-name': 'core-mobile-ios' } }),
+        expect.anything(),
+      );
+    });
+
+    it('resolves auth headers per request, merged over static headers', async () => {
+      jest.clearAllMocks();
+      (Glacier as jest.Mock).mockReturnValue(mockGlacier);
+      const getAuthHeaders = jest.fn().mockResolvedValue({ 'X-Firebase-AppCheck': 'token-1' });
+
+      new EvmGlacierService({
+        glacierApiUrl: FAKE_URL,
+        headers: { 'x-application-name': 'core-mobile-ios' },
+        getAuthHeaders,
+      });
+
+      const config = (Glacier as jest.Mock).mock.calls[0]?.[0];
+      expect(typeof config.HEADERS).toBe('function');
+      await expect(config.HEADERS()).resolves.toEqual({
+        'x-application-name': 'core-mobile-ios',
+        'X-Firebase-AppCheck': 'token-1',
+      });
+
+      getAuthHeaders.mockResolvedValue({ 'X-Firebase-AppCheck': 'token-2' });
+      await expect(config.HEADERS()).resolves.toEqual({
+        'x-application-name': 'core-mobile-ios',
+        'X-Firebase-AppCheck': 'token-2',
+      });
+    });
+  });
+
   describe('isNetworkSupported', () => {
     it('Should return false if Ethereum main chain ID is passed in', async () => {
       (mockGlacier.evmChains as jest.Mocked<EvmChainsService>).supportedChains.mockResolvedValue({

--- a/packages/evm-module/src/services/glacier-service/glacier-service.ts
+++ b/packages/evm-module/src/services/glacier-service/glacier-service.ts
@@ -33,6 +33,11 @@ const CHAINS_TO_FILTER = [ChainId.ETHEREUM_HOMESTEAD];
 type GlacierServiceConfig = {
   glacierApiUrl: string;
   headers?: Record<string, string>;
+  /**
+   * Resolves per-request auth headers (e.g. a Firebase AppCheck token) required
+   * by the Glacier proxy. Merged over the static `headers`.
+   */
+  getAuthHeaders?: () => Promise<Record<string, string> | undefined>;
 };
 
 export class EvmGlacierService implements BalanceServiceInterface {
@@ -40,11 +45,11 @@ export class EvmGlacierService implements BalanceServiceInterface {
   isGlacierHealthy = true;
   supportedChainIds: string[] = [];
 
-  constructor({ glacierApiUrl, headers }: GlacierServiceConfig) {
+  constructor({ glacierApiUrl, headers, getAuthHeaders }: GlacierServiceConfig) {
     this.glacierSdk = new Glacier(
       {
         BASE: glacierApiUrl,
-        HEADERS: headers,
+        HEADERS: getAuthHeaders ? async () => ({ ...headers, ...(await getAuthHeaders()) }) : headers,
       },
       GlacierFetchHttpRequest,
     );

--- a/packages/types/src/module.ts
+++ b/packages/types/src/module.ts
@@ -35,6 +35,12 @@ export type ConstructorParams = {
 export type RuntimeParams = {
   fetch?: typeof fetch;
   httpAgent?: Agent;
+  /**
+   * Resolves auth headers (e.g. a Firebase AppCheck token) attached to requests
+   * against Core's authenticated proxies, such as Glacier via core-proxy-api.
+   * Invoked per request, so short-lived tokens are re-read on every call.
+   */
+  getAuthHeaders?: () => Promise<Record<string, string>>;
 };
 
 export type NetworkFeeParam = Network & { caipId?: string };

--- a/packages/types/src/module.ts
+++ b/packages/types/src/module.ts
@@ -39,6 +39,8 @@ export type RuntimeParams = {
    * Resolves auth headers (e.g. a Firebase AppCheck token) attached to requests
    * against Core's authenticated proxies, such as Glacier via core-proxy-api.
    * Invoked per request, so short-lived tokens are re-read on every call.
+   * Optional here; the EVM and Avalanche modules require it in their
+   * constructor params since their Glacier calls cannot succeed without it.
    */
   getAuthHeaders?: () => Promise<Record<string, string>>;
 };


### PR DESCRIPTION
## Context

Part of the Glacier migration ([CP-14847](https://ava-labs.atlassian.net/browse/CP-14847), blocks [CP-14673](https://ava-labs.atlassian.net/browse/CP-14673) mobile / [CP-14867](https://ava-labs.atlassian.net/browse/CP-14867) extension). Per BE, `glacier-api.avax.network` stays up but its **EVM endpoints are being removed** — all clients must switch to the new smart-routing proxy (`/v1/proxy/glacier` on core-proxy-api), which **requires auth**: a Firebase AppCheck token (`x-firebase-appcheck`) or a per-client Core API key (`x-core-api-key`). The modules hardcode the old Glacier hosts and give consumers no way to attach auth headers to internal Glacier calls.

## Changes (BREAKING — major)

- **`env.ts` (evm + avalanche)**: `glacierApiUrl` → `https://core-proxy-api.avax.network/v1/proxy/glacier` (prod) / `https://core-proxy-api.avax-test.network/v1/proxy/glacier` (dev).
- **`RuntimeParams.getAuthHeaders`** (types): async resolver for auth headers, resolved **per request** so short-lived tokens stay fresh. Optional in the shared type, but **required in the `EvmModule` and `AvalancheModule` constructor params** — those modules cannot function against the proxy without it, so the break is compile-time rather than mysterious runtime 401s (thanks @meeh0w).
- **Glacier services** (`EvmGlacierService`, `AvalancheGlacierService`): pass the resolver to the glacier-sdk's `HEADERS` config as an async resolver merged over the static core headers. Wired as a closure over `#runtime`, so `EvmModule.updateRuntimeParams()` is respected.
- **`avalanche_sign/sendTransaction` handlers**: merge resolved auth headers into the `getUtxosByTxFromGlacier` call.
- **bitcoin-module**: removed the unused `glacierApiUrl` from env (bitcoin goes through the proxy-api CF worker, unchanged).
- **`addGlacierAPIKeyIfNeeded`**: added the core-proxy hosts to `knownHosts`.

## Notes for consumers

- Pass `getAuthHeaders` returning `{'x-firebase-appcheck': token}` (prod) — dev/E2E builds can instead/additionally use the per-client Core API key (`x-core-api-key`, 1Password front-end-eng vault → "Core API keys"), which authorizes **and** bypasses rate limits.
- The legacy client-side `rltoken` (`GLACIER_API_KEY`) has no effect through the proxy — the proxy injects its own rate-limit bypass upstream. Removing the legacy `rltoken` plumbing is deliberately left to a follow-up to keep this PR reviewable.
- core-mobile: CP-14673 · core-extension: CP-14867

## Testing

- New unit tests: header-resolver merge + refresh in both Glacier services, auth-header merge in both avalanche tx handlers, core-proxy hosts in `add-glacier-api-key-if-needed`.
- `turbo test lint build` green across the affected packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)