### PR TITLE
fix: export parseEercTransaction helper

### DIFF
--- a/.changeset/eleven-hotels-pump.md
+++ b/.changeset/eleven-hotels-pump.md
@@ -1,0 +1,5 @@
+---
+'@avalabs/evm-module': patch
+---
+
+Exports parseEercTransaction utility function

--- a/packages/evm-module/src/index.ts
+++ b/packages/evm-module/src/index.ts
@@ -2,3 +2,4 @@ export * from './module';
 export * from './types';
 export * from './handlers/eth-sign/utils/typeguards';
 export * from './utils/id-promise';
+export * from './utils/parse-eerc-transaction';


### PR DESCRIPTION
Exports the `parseEercTransaction` util function to allow client apps to also recognize these transactions (i.e. for analytics purposes).