### PR TITLE
chore: migrate CODEOWNERS to @ava-labs/core-engineering

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for the entire repository
-* @ava-labs/core-backend @ava-labs/core-extension @ava-labs/core-web @ava-labs/core-mobile
+* @ava-labs/core-engineering


### PR DESCRIPTION
Replaces references to the retired teams (`core-backend`, `core-extension`, `core-mobile`, `Core-QA`, `Core-web`, `core-web-ext`) with the new consolidated `@ava-labs/core-engineering` team.

Part of the team consolidation effort. Duplicate handles produced by collapsing multiple old teams onto a single rule were de-duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)