### PR TITLE
fix: bump avalanchejs to 5.1.1-alpha.2 for final ACP-236 wire format

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
   "pnpm": {
     "patchedDependencies": {
       "jest-runner@29.7.0": "patches/jest-runner@29.7.0.patch"
+    },
+    "overrides": {
+      "@avalabs/avalanchejs": "5.1.1-alpha.2"
     }
   }
 }

--- a/packages/avalanche-module/package.json
+++ b/packages/avalanche-module/package.json
@@ -22,7 +22,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@avalabs/avalanchejs": "5.1.0-alpha.4",
+    "@avalabs/avalanchejs": "5.1.1-alpha.2",
     "@avalabs/core-chains-sdk": "3.1.0-alpha.87",
     "@avalabs/core-coingecko-sdk": "3.1.0-alpha.87",
     "@avalabs/core-etherscan-sdk": "3.1.0-alpha.87",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@avalabs/avalanchejs': 5.1.1-alpha.2
+
 patchedDependencies:
   jest-runner@29.7.0:
     hash: a919f065dabfb40b85cdb7063b9e5ceec3cab6ea40577ad4edd2f1999ba5aa47
@@ -134,7 +137,7 @@ importers:
         version: 29.7.0(@types/node@25.0.6)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(esbuild@0.18.20)(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
+        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -142,8 +145,8 @@ importers:
   packages/avalanche-module:
     dependencies:
       '@avalabs/avalanchejs':
-        specifier: 5.1.0-alpha.4
-        version: 5.1.0-alpha.4
+        specifier: 5.1.1-alpha.2
+        version: 5.1.1-alpha.2
       '@avalabs/core-chains-sdk':
         specifier: 3.1.0-alpha.87
         version: 3.1.0-alpha.87(big.js@6.2.1)(bn.js@5.2.1)(ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10))(node-fetch@2.7.0)
@@ -207,7 +210,7 @@ importers:
         version: 29.7.0(@types/node@25.0.6)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(esbuild@0.18.20)(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
+        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
       tsup:
         specifier: 7.2.0
         version: 7.2.0(typescript@5.8.2)
@@ -268,7 +271,7 @@ importers:
         version: 29.7.0(@types/node@25.0.6)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(esbuild@0.18.20)(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
+        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
       tsup:
         specifier: 7.2.0
         version: 7.2.0(typescript@5.8.2)
@@ -356,7 +359,7 @@ importers:
         version: 29.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(esbuild@0.18.20)(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
+        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
       tsup:
         specifier: 7.2.0
         version: 7.2.0(typescript@5.8.2)
@@ -414,7 +417,7 @@ importers:
         version: 29.7.0(@types/node@25.0.6)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(esbuild@0.18.20)(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
+        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
       tsup:
         specifier: 7.2.0
         version: 7.2.0(typescript@5.8.2)
@@ -463,7 +466,7 @@ importers:
         version: 29.7.0(@types/node@25.0.6)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(esbuild@0.18.20)(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
+        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
       tsup:
         specifier: 7.2.0
         version: 7.2.0(typescript@5.8.2)
@@ -542,7 +545,7 @@ importers:
         version: 29.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(esbuild@0.18.20)(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
+        version: 29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2)
       tsup:
         specifier: 7.2.0
         version: 7.2.0(typescript@5.8.2)
@@ -604,8 +607,8 @@ packages:
   '@adraffy/ens-normalize@1.10.1':
     resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
 
-  '@avalabs/avalanchejs@5.1.0-alpha.4':
-    resolution: {integrity: sha512-xOhTG8fHnJ4yf56w6lsj4skYTTUcvPX0dDKmA2KovX+5HZlbuku6/TrDka+pRYK9Yycg/QJHwA3fdITsRsGhlQ==}
+  '@avalabs/avalanchejs@5.1.1-alpha.2':
+    resolution: {integrity: sha512-ko/1SIlARn7qYxPVD0O7V0s0glaXAedYWIo7XdXD3RcpSSeZeSk4yYaG4HZvKdzK//m7OE77vV11laN/jodaTQ==}
     engines: {node: '>=20'}
 
   '@avalabs/core-chains-sdk@3.1.0-alpha.61':
@@ -6422,7 +6425,7 @@ snapshots:
 
   '@adraffy/ens-normalize@1.10.1': {}
 
-  '@avalabs/avalanchejs@5.1.0-alpha.4':
+  '@avalabs/avalanchejs@5.1.1-alpha.2':
     dependencies:
       '@noble/curves': 1.3.0
       '@noble/hashes': 1.3.3
@@ -6546,7 +6549,7 @@ snapshots:
 
   '@avalabs/core-wallets-sdk@3.1.0-alpha.87(@solana/sysvars@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))(big.js@6.2.1)(bn.js@5.2.2)(ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(node-fetch@2.7.0)(react@18.3.1)(typescript@5.8.2)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
-      '@avalabs/avalanchejs': 5.1.0-alpha.4
+      '@avalabs/avalanchejs': 5.1.1-alpha.2
       '@avalabs/core-chains-sdk': 3.1.0-alpha.61(big.js@6.2.1)(bn.js@5.2.2)(ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10))(node-fetch@2.7.0)
       '@avalabs/core-utils-sdk': 3.1.0-alpha.61(big.js@6.2.1)(bn.js@5.2.2)(ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10))(node-fetch@2.7.0)
       '@avalabs/glacier-sdk': 3.1.0-alpha.61
@@ -6590,7 +6593,7 @@ snapshots:
 
   '@avalabs/core-wallets-sdk@3.1.0-alpha.87(@solana/sysvars@2.1.0(typescript@5.8.2))(big.js@6.2.1)(bn.js@5.2.1)(ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10))(node-fetch@2.7.0)(react@18.3.1)(typescript@5.8.2)':
     dependencies:
-      '@avalabs/avalanchejs': 5.1.0-alpha.4
+      '@avalabs/avalanchejs': 5.1.1-alpha.2
       '@avalabs/core-chains-sdk': 3.1.0-alpha.61(big.js@6.2.1)(bn.js@5.2.1)(ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10))(node-fetch@2.7.0)
       '@avalabs/core-utils-sdk': 3.1.0-alpha.61(big.js@6.2.1)(bn.js@5.2.1)(ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10))(node-fetch@2.7.0)
       '@avalabs/glacier-sdk': 3.1.0-alpha.61
@@ -13456,7 +13459,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(esbuild@0.18.20)(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2):
+  ts-jest@29.1.1(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest@29.7.0(@types/node@25.0.6))(typescript@5.8.2):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -13472,7 +13475,6 @@ snapshots:
       '@babel/core': 7.28.5
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.28.5)
-      esbuild: 0.18.20
 
   tsconfig-paths@3.15.0:
     dependencies:


### PR DESCRIPTION
Since Helicon activated on Fuji, `avalanche_sendTransaction` fails to parse `AddAutoRenewedValidatorTx` before the approval popup (`couldn't unmarshal interface: unknown type ID …`): the pinned avalanchejs `5.1.0-alpha.4` has the **draft** ACP-236 wire format, while Fuji activated with the **final** format (only in `5.1.1-alpha.2`).

- Bump `@avalabs/avalanchejs` → `5.1.1-alpha.2` in avalanche-module
- Root pnpm override so the workspace resolves a single copy (two copies = cross-package type conflicts)

137/137 avalanche-module tests pass, no new tsc errors vs `main`. The same tx bytes are verified accepted by live Fuji `avalanchego/1.15.0`. Note: `core-wallets-sdk` pins its own avalanchejs and likely needs the same bump for a full release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
